### PR TITLE
feat(llm): add api_key_cmd config for command-based key retrieval

### DIFF
--- a/scaffold/ori.config.yaml
+++ b/scaffold/ori.config.yaml
@@ -42,6 +42,7 @@ llm:
   provider: null           # "anthropic" | "openai" (OpenAI-compatible)
   model: null              # e.g. "claude-sonnet-4-20250514", "gpt-4o", "qwen2.5"
   api_key_env: null        # env var name containing API key
+  api_key_cmd: null        # shell command whose stdout is the API key (tried before api_key_env)
   base_url: null           # API base URL (null = provider default)
   # Examples:
   #   Anthropic:  provider: "anthropic", model: "claude-sonnet-4-20250514", api_key_env: "ANTHROPIC_API_KEY"

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -306,6 +306,7 @@ export function applyConfigDefaults(raw: Partial<OriConfig>): OriConfig {
       provider: rawLlm?.provider ?? DEFAULT_LLM_CONFIG.provider,
       model: rawLlm?.model ?? DEFAULT_LLM_CONFIG.model,
       api_key_env: rawLlm?.api_key_env ?? DEFAULT_LLM_CONFIG.api_key_env,
+      api_key_cmd: rawLlm?.api_key_cmd ?? DEFAULT_LLM_CONFIG.api_key_cmd,
       base_url: (rawLlm as Record<string, unknown> | undefined)?.base_url as string | null ?? DEFAULT_LLM_CONFIG.base_url,
     },
     promote: {

--- a/src/core/llm.ts
+++ b/src/core/llm.ts
@@ -1,3 +1,5 @@
+import { execSync } from "node:child_process";
+
 /* ------------------------------------------------------------------ */
 /*  Chat interface (generic LLM calls for explore recursion)           */
 /* ------------------------------------------------------------------ */
@@ -35,6 +37,7 @@ export type LlmConfig = {
   provider: string | null;
   model: string | null;
   api_key_env: string | null;
+  api_key_cmd: string | null;
   base_url: string | null;
 };
 
@@ -42,6 +45,7 @@ export const DEFAULT_LLM_CONFIG: LlmConfig = {
   provider: null,
   model: null,
   api_key_env: null,
+  api_key_cmd: null,
   base_url: null,
 };
 
@@ -71,6 +75,29 @@ export class NullProvider implements LlmProvider {
   }
 }
 
+function resolveApiKey(config: LlmConfig): string | undefined {
+  if (config.api_key_cmd) {
+    try {
+      const key = execSync(config.api_key_cmd, {
+        encoding: "utf-8",
+        timeout: 5000,
+        stdio: ["ignore", "pipe", "pipe"],
+      }).trim();
+      if (key) {
+        return key;
+      }
+    } catch (err) {
+      console.error(`api_key_cmd failed: ${(err as Error).message}`);
+    }
+  }
+
+  if (config.api_key_env) {
+    return process.env[config.api_key_env];
+  }
+
+  return undefined;
+}
+
 /**
  * Create provider from config. Returns NullProvider when provider is null.
  */
@@ -79,9 +106,7 @@ export async function createProvider(config: LlmConfig): Promise<LlmProvider> {
     return new NullProvider();
   }
 
-  const apiKey = config.api_key_env
-    ? process.env[config.api_key_env]
-    : undefined;
+  const apiKey = resolveApiKey(config);
 
   if (!apiKey) {
     return new NullProvider();

--- a/tests/core/config.test.ts
+++ b/tests/core/config.test.ts
@@ -122,6 +122,37 @@ describe("loadConfig", () => {
   });
 });
 
+describe("api_key_cmd config", () => {
+  it("defaults api_key_cmd to null", () => {
+    const config = applyConfigDefaults({});
+    expect(config.llm.api_key_cmd).toBeNull();
+  });
+
+  it("preserves api_key_cmd when provided", () => {
+    const config = applyConfigDefaults({
+      llm: {
+        provider: "anthropic",
+        model: "claude-sonnet-4-20250514",
+        api_key_env: null,
+        api_key_cmd: "pass anthropic/api-key",
+        base_url: null,
+      },
+    });
+    expect(config.llm.api_key_cmd).toBe("pass anthropic/api-key");
+  });
+
+  it("loads api_key_cmd from YAML config", async () => {
+    const configPath = path.join(tmpDir, "ori.config.yaml");
+    await fs.writeFile(
+      configPath,
+      "llm:\n  provider: anthropic\n  model: claude-sonnet-4-20250514\n  api_key_cmd: \"pass anthropic/api-key\"\n",
+      "utf8"
+    );
+    const config = await loadConfig(configPath);
+    expect(config.llm.api_key_cmd).toBe("pass anthropic/api-key");
+  });
+});
+
 describe("resolveTemplatePath", () => {
   const config = applyConfigDefaults({
     templates: {


### PR DESCRIPTION
Closes #3

Adds `api_key_cmd` as an alternative to `api_key_env`. Runs the
configured command and uses its stdout as the API key. Falls back
to `api_key_env` if the command fails or returns empty output.

The command runs with a 5s timeout, stdin suppressed, and stderr
captured. Failures log a warning rather than silently falling back.
Key resolution lives in its own `resolveApiKey()` function.