### PR TITLE
fix(linkdetect): reduce suggestLinks noise with structural top-5 cap and project size filter

### DIFF
--- a/src/core/linkdetect.test.ts
+++ b/src/core/linkdetect.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { suggestLinks, type VaultIndex } from "./linkdetect.js";
+
+function makeVaultIndex(
+  titles: string[],
+  frontmatter: Map<string, Record<string, unknown>> = new Map(),
+): VaultIndex {
+  return {
+    titles,
+    frontmatter,
+    graph: { outgoing: new Map(), incoming: new Map() },
+  };
+}
+
+describe("suggestLinks", () => {
+  it("skips project-overlap when project has more than 10 notes", () => {
+    // 15 notes all sharing the same project
+    const titles = Array.from({ length: 15 }, (_, i) => `note-${i}`);
+    const frontmatter = new Map(
+      titles.map((t) => [t, { project: ["big-project"] }]),
+    );
+    const vaultIndex = makeVaultIndex(titles, frontmatter);
+
+    const suggestions = suggestLinks(
+      { project: ["big-project"] },
+      "some body text with no title matches",
+      vaultIndex,
+    );
+
+    const projectSuggestions = suggestions.filter(
+      (s) => s.reason === "project-overlap",
+    );
+    expect(projectSuggestions).toHaveLength(0);
+  });
+
+  it("keeps project-overlap when project has 10 or fewer notes", () => {
+    const titles = ["note-a", "note-b", "note-c"];
+    const frontmatter = new Map(
+      titles.map((t) => [t, { project: ["small-project"] }]),
+    );
+    const vaultIndex = makeVaultIndex(titles, frontmatter);
+
+    const suggestions = suggestLinks(
+      { project: ["small-project"] },
+      "unrelated body",
+      vaultIndex,
+    );
+
+    const projectSuggestions = suggestions.filter(
+      (s) => s.reason === "project-overlap",
+    );
+    expect(projectSuggestions.length).toBeGreaterThan(0);
+  });
+
+  it("caps total suggestions to 5", () => {
+    // 8 notes with tag overlap to generate many suggestions
+    const titles = Array.from({ length: 8 }, (_, i) => `tagged-${i}`);
+    const frontmatter = new Map(
+      titles.map((t) => [t, { tags: ["common-tag"] }]),
+    );
+    const vaultIndex = makeVaultIndex(titles, frontmatter);
+
+    const suggestions = suggestLinks(
+      { tags: ["common-tag"] },
+      "unrelated body",
+      vaultIndex,
+    );
+
+    expect(suggestions.length).toBeLessThanOrEqual(5);
+  });
+});

--- a/src/core/linkdetect.ts
+++ b/src/core/linkdetect.ts
@@ -160,14 +160,23 @@ export function suggestLinks(
     }
   }
 
-  // Project overlap
+  // Project overlap (skip when a project has too many notes to be a useful signal)
   if (noteProject.length > 0) {
+    const projectSizes = new Map<string, number>();
+    for (const [, fm] of vaultIndex.frontmatter) {
+      const projects = Array.isArray(fm.project) ? (fm.project as string[]) : [];
+      for (const p of projects)
+        projectSizes.set(p, (projectSizes.get(p) ?? 0) + 1);
+    }
+
     for (const [title, fm] of vaultIndex.frontmatter) {
       if (suggestions.has(title)) continue;
       const otherProject = Array.isArray(fm.project)
         ? (fm.project as string[])
         : [];
-      const overlap = noteProject.filter((p) => otherProject.includes(p));
+      const overlap = noteProject.filter(
+        (p) => otherProject.includes(p) && (projectSizes.get(p) ?? 0) <= 10,
+      );
       if (overlap.length > 0) {
         suggestions.set(title, {
           title,
@@ -227,9 +236,9 @@ export function suggestLinks(
     }
   }
 
-  return Array.from(suggestions.values()).sort(
-    (a, b) => b.confidence - a.confidence
-  );
+  return Array.from(suggestions.values())
+    .sort((a, b) => b.confidence - a.confidence)
+    .slice(0, 5);
 }
 
 /**


### PR DESCRIPTION
Fixes #9.

Structural suggestions are now capped to the top 5 by confidence, so title matches (0.9) aren't buried by weaker signals. `suggestLinksWithSemantic` already limits its own output to 5, so the combined max is 10.

Project overlap is skipped for projects with more than 10 notes - at that size the shared tag doesn't tell you much about whether two notes should be linked.

Tests for both.