### PR TITLE
fix: remove shell: true from spawnSync calls in hooks (CWE-78)

### DIFF
--- a/adapters/claude-code/hooks/capture.mjs
+++ b/adapters/claude-code/hooks/capture.mjs
@@ -58,6 +58,6 @@ if (!findVaultRoot(process.cwd())) {
   process.exit(0);
 }
 
-const result = spawnSync("ori", ["add", title, "--type", "insight"], { stdio: "inherit", shell: true });
+const result = spawnSync("ori", ["add", title, "--type", "insight"], { stdio: "inherit" });
 if (result.error) process.exit(0);
 process.exit(result.status ?? 0);

--- a/adapters/claude-code/hooks/orient.mjs
+++ b/adapters/claude-code/hooks/orient.mjs
@@ -27,12 +27,11 @@ if (!vaultRoot) {
 const healthResult = spawnSync("ori", ["health"], {
   encoding: "utf8",
   timeout: 8000,
-  shell: true,
 });
 
 if (healthResult.error || healthResult.status !== 0) {
   // Fallback to basic status
-  const result = spawnSync("ori", ["status"], { stdio: "inherit", shell: true });
+  const result = spawnSync("ori", ["status"], { stdio: "inherit" });
   process.exit(result.status ?? 0);
 }
 
@@ -89,7 +88,6 @@ try {
     const gitResult = spawnSync("git", ["remote", "get-url", "origin"], {
       encoding: "utf8",
       timeout: 3000,
-      shell: true,
     });
     if (!gitResult.error && gitResult.stdout) {
       const repoName = path
@@ -104,7 +102,7 @@ try {
   console.log(lines.join("\n"));
 } catch {
   // JSON parse failed, fall back to status
-  const result = spawnSync("ori", ["status"], { stdio: "inherit", shell: true });
+  const result = spawnSync("ori", ["status"], { stdio: "inherit" });
   process.exit(result.status ?? 0);
 }
 

--- a/adapters/claude-code/hooks/validate.mjs
+++ b/adapters/claude-code/hooks/validate.mjs
@@ -63,6 +63,6 @@ if (!normalizedFile.startsWith(normalizedVault)) {
   process.exit(0);
 }
 
-const result = spawnSync("ori", ["validate", filePath], { stdio: "inherit", shell: true });
+const result = spawnSync("ori", ["validate", filePath], { stdio: "inherit" });
 if (result.error) process.exit(0);
 process.exit(result.status ?? 0);


### PR DESCRIPTION
## Summary
- Removes `shell: true` from all 6 `spawnSync` call sites across `capture.mjs`, `validate.mjs`, and `orient.mjs`
- None of these calls use shell features — passing args arrays directly to the executable is functionally identical and eliminates command injection vectors via user-controlled inputs (session summaries, file paths)
- Dependency CVEs (`npm audit fix`) will be addressed in a separate pass

Closes #15