### PR TITLE
fix(cli): resolve relative paths against vault root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ tests/core/*
 !tests/core/stage-learner.test.ts
 !tests/core/dampening.test.ts
 !tests/core/classify.test.ts
+!tests/core/vault-path.test.ts
 !tests/mcp/
 tests/mcp/*
 !tests/mcp/server.test.ts

--- a/README.md
+++ b/README.md
@@ -317,6 +317,9 @@ ori bridge status [--json]                                             # Inspect
 ori bridge <target> --uninstall                                        # Remove Ori config for a target
 ```
 
+Path-taking commands treat relative file paths as vault-relative. Absolute
+paths continue to work unchanged.
+
 ---
 
 ## Vault Structure

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -620,7 +620,7 @@ export async function runServeMcp(startDir: string, vaultOverride?: string) {
       path: z.string().describe("Path to note file"),
     },
     async ({ path }) => {
-      const result = await runValidate({ notePath: path });
+      const result = await runValidate({ notePath: path, startDir: vaultDir });
       return textResult(result);
     }
   );

--- a/src/cli/validate.ts
+++ b/src/cli/validate.ts
@@ -1,20 +1,23 @@
 import path from "node:path";
 import { loadConfig, resolveTemplatePath } from "../core/config.js";
-import { findVaultRoot, getVaultPaths } from "../core/vault.js";
+import { findVaultRoot, getVaultPaths, resolveVaultPath } from "../core/vault.js";
 import { validateNoteAgainstSchema } from "../core/schema.js";
 import { parseFrontmatter } from "../core/frontmatter.js";
 import { promises as fs } from "node:fs";
 
 export type ValidateOptions = {
   notePath: string;
+  startDir?: string;
 };
 
 export async function runValidate(
   options: ValidateOptions
 ): Promise<{ success: boolean; errors: string[]; warnings: string[] }>
 {
-  const absoluteNotePath = path.resolve(options.notePath);
-  const vaultRoot = await findVaultRoot(path.dirname(absoluteNotePath));
+  const vaultRoot = path.isAbsolute(options.notePath)
+    ? await findVaultRoot(path.dirname(path.resolve(options.notePath)))
+    : await findVaultRoot(options.startDir ?? process.cwd());
+  const absoluteNotePath = resolveVaultPath(vaultRoot, options.notePath);
   const vaultPaths = getVaultPaths(vaultRoot);
   const config = await loadConfig(vaultPaths.config);
 

--- a/src/core/vault.ts
+++ b/src/core/vault.ts
@@ -88,6 +88,12 @@ export function getVaultPaths(root: string): VaultPaths {
   };
 }
 
+export function resolveVaultPath(vaultRoot: string, inputPath: string): string {
+  return path.isAbsolute(inputPath)
+    ? path.resolve(inputPath)
+    : path.resolve(vaultRoot, inputPath);
+}
+
 export async function listNoteTitles(notesDir: string): Promise<string[]> {
   try {
     const entries = await fs.readdir(notesDir, { withFileTypes: true });

--- a/tests/core/vault-path.test.ts
+++ b/tests/core/vault-path.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runInit } from "../../src/cli/init.js";
+import { runValidate } from "../../src/cli/validate.js";
+import { resolveVaultPath } from "../../src/core/vault.js";
+
+async function makeTempDir(prefix: string): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+describe("vault-relative paths", () => {
+  it("resolves relative paths against the vault root", () => {
+    const vaultRoot = path.resolve("tmp-vault");
+    expect(resolveVaultPath(vaultRoot, "notes/example.md")).toBe(
+      path.resolve(vaultRoot, "notes/example.md"),
+    );
+  });
+
+  it("preserves absolute paths", () => {
+    const absolutePath = path.resolve("elsewhere", "example.md");
+    expect(resolveVaultPath(path.resolve("tmp-vault"), absolutePath)).toBe(absolutePath);
+  });
+
+  it("validates vault-relative note paths when the caller is outside the vault", async () => {
+    const vaultDir = await makeTempDir("ori-validate-vault-");
+    const projectDir = await makeTempDir("ori-validate-project-");
+    const originalCwd = process.cwd();
+
+    try {
+      await runInit({ targetDir: vaultDir });
+      process.chdir(projectDir);
+      const notePath = path.join(vaultDir, "notes", "vault-relative-validation.md");
+      await fs.writeFile(
+        notePath,
+        [
+          "---",
+          "description: Validates vault-relative path handling",
+          "type: insight",
+          "project:",
+          "  - cli",
+          "status: active",
+          "created: 2026-05-05",
+          "---",
+          "",
+          "# Vault relative validation works",
+          "",
+          "Relative paths should resolve inside the vault even when the caller is elsewhere.",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const result = await runValidate({
+        startDir: vaultDir,
+        notePath: "notes/vault-relative-validation.md",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.errors).toEqual([]);
+    } finally {
+      process.chdir(originalCwd);
+      await fs.rm(vaultDir, { recursive: true, force: true });
+      await fs.rm(projectDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared vault-relative path resolver
- make `ori_validate` resolve relative paths against the vault root
- pass the MCP server vault root into `ori_validate`
- document the path policy
- add regression coverage for invocation from outside the vault

Fixes #21

## Tests
- `npm run build`
- `npx vitest run tests/core/vault-path.test.ts --environment node`