### PR TITLE
fix(promote): wire LLM enhancement into promotion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ tests/core/*
 !tests/core/dampening.test.ts
 !tests/core/classify.test.ts
 !tests/core/vault-path.test.ts
+!tests/core/promote-llm.test.ts
 !tests/mcp/
 tests/mcp/*
 !tests/mcp/server.test.ts

--- a/scaffold/ori.config.yaml
+++ b/scaffold/ori.config.yaml
@@ -33,7 +33,6 @@ vitality:
 promote:
   auto: true               # ori add auto-promotes to notes/
   require_llm: false       # true = only auto-promote when LLM available
-  min_confidence: 0.6      # below this, skip auto-promotion and warn
   project_keywords: {}     # project_name: [keyword, keyword, ...]
   project_map_routing: {}  # project_name: map_note_title
   default_area: "index"    # fallback area when no project match

--- a/src/cli/promote.ts
+++ b/src/cli/promote.ts
@@ -8,6 +8,13 @@ import { validateNoteAgainstSchema } from "../core/schema.js";
 import { computePromotion, isTemplatePlaceholder, type PromoteResult } from "../core/promote.js";
 import type { VaultIndex } from "../core/linkdetect.js";
 import type { ProjectKeywordConfig } from "../core/classify.js";
+import {
+  createProvider,
+  NullProvider,
+  type EnhancementSuggestions,
+  type VaultContext,
+} from "../core/llm.js";
+
 export type PromoteOptions = {
   startDir: string;
   noteName?: string;
@@ -37,10 +44,11 @@ export type PromoteCommandResult = {
   warnings: string[];
 };
 
-function getPromoteConfig(config: { promote: { project_keywords: Record<string, string[]>; project_map_routing: Record<string, string>; default_area: string } }): {
+function getPromoteConfig(config: { promote: { project_keywords: Record<string, string[]>; project_map_routing: Record<string, string>; default_area: string; require_llm: boolean } }): {
   projectConfig: ProjectKeywordConfig;
   mapRouting: Record<string, string>;
   defaultArea: string;
+  requireLlm: boolean;
 } {
   return {
     projectConfig: {
@@ -49,6 +57,7 @@ function getPromoteConfig(config: { promote: { project_keywords: Record<string, 
     },
     mapRouting: config.promote.project_map_routing,
     defaultArea: config.promote.default_area,
+    requireLlm: config.promote.require_llm,
   };
 }
 
@@ -72,6 +81,50 @@ async function buildVaultIndex(
   }
 
   return { titles, frontmatter, graph };
+}
+
+function buildVaultContext(vaultIndex: VaultIndex): VaultContext {
+  const recentNotes = [...vaultIndex.frontmatter.entries()].slice(0, 10).map(
+    ([title, data]) => ({
+      title,
+      type: typeof data.type === "string" ? data.type : "",
+      description: typeof data.description === "string" ? data.description : "",
+    }),
+  );
+  const projectTags = new Set<string>();
+  for (const data of vaultIndex.frontmatter.values()) {
+    const projects = data.project;
+    if (!Array.isArray(projects)) continue;
+    for (const project of projects) {
+      if (typeof project === "string" && project.trim()) projectTags.add(project);
+    }
+  }
+  return {
+    existingTitles: vaultIndex.titles,
+    recentNotes,
+    projectTags: [...projectTags].sort(),
+  };
+}
+
+function titleFromFilename(filename: string): string {
+  return filename.replace(/\.md$/, "").replace(/-/g, " ");
+}
+
+function mergeEnhancementOverrides(
+  options: PromoteOptions,
+  suggestions: EnhancementSuggestions,
+): {
+  type?: string;
+  description?: string;
+  links?: string[];
+  project?: string[];
+} {
+  return {
+    type: options.type ?? suggestions.type,
+    description: options.description ?? suggestions.description,
+    links: options.links,
+    project: options.project ?? suggestions.project,
+  };
 }
 
 async function listInboxNotes(inboxDir: string): Promise<string[]> {
@@ -101,8 +154,11 @@ export async function runPromote(
   const vaultRoot = await findVaultRoot(options.startDir);
   const paths = getVaultPaths(vaultRoot);
   const config = await loadConfig(paths.config);
-  const { projectConfig, mapRouting, defaultArea } = getPromoteConfig(config);
+  const { projectConfig, mapRouting, defaultArea, requireLlm } = getPromoteConfig(config);
   const vaultIndex = await buildVaultIndex(paths.notes);
+  const vaultContext = buildVaultContext(vaultIndex);
+  const provider = await createProvider(config.llm);
+  const hasLlm = !(provider instanceof NullProvider);
 
   // Resolve target inbox notes
   const allInbox = await listInboxNotes(paths.inbox);
@@ -134,6 +190,20 @@ export async function runPromote(
   const promoted: PromotedNote[] = [];
   const skipped: Array<{ path: string; reason: string }> = [];
 
+  if (requireLlm && !hasLlm) {
+    return {
+      success: true,
+      data: {
+        promoted,
+        skipped: targets.map((filename) => ({
+          path: path.join(paths.inbox, filename),
+          reason: "LLM enhancement required but no provider is configured",
+        })),
+      },
+      warnings: ["LLM enhancement required but no provider is configured"],
+    };
+  }
+
   for (const filename of targets) {
     const inboxPath = path.join(paths.inbox, filename);
     const parsed = await readFrontmatterFile(inboxPath);
@@ -161,6 +231,18 @@ export async function runPromote(
       continue;
     }
 
+    let enhancement: EnhancementSuggestions = {};
+    if (hasLlm) {
+      enhancement = await provider.enhance(
+        {
+          title: titleFromFilename(filename),
+          body: parsed.body,
+          frontmatter: parsed.data,
+        },
+        vaultContext,
+      );
+    }
+
     // Compute promotion
     const result: PromoteResult = computePromotion({
       inboxPath,
@@ -168,16 +250,15 @@ export async function runPromote(
       body: parsed.body,
       existingTitles: vaultIndex.titles,
       vaultIndex,
-      overrides: {
-        type: options.type,
-        description: options.description,
-        links: options.links,
-        project: options.project,
-      },
+      overrides: mergeEnhancementOverrides(options, enhancement),
       projectConfig,
       mapRouting,
       defaultArea,
     });
+
+    if (enhancement.reasoning) {
+      result.changes.push(`LLM reasoning: ${enhancement.reasoning}`);
+    }
 
     const destPath = path.join(paths.notes, result.destinationFilename);
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -33,7 +33,6 @@ export type VitalityConfig = {
 export type PromoteConfig = {
   auto: boolean;
   require_llm: boolean;
-  min_confidence: number;
   project_keywords: Record<string, string[]>;
   project_map_routing: Record<string, string>;
   default_area: string;
@@ -142,7 +141,6 @@ export type OriConfig = {
 const DEFAULT_PROMOTE_CONFIG: PromoteConfig = {
   auto: true,
   require_llm: false,
-  min_confidence: 0.6,
   project_keywords: {},
   project_map_routing: {},
   default_area: "index",
@@ -312,8 +310,6 @@ export function applyConfigDefaults(raw: Partial<OriConfig>): OriConfig {
     promote: {
       auto: rawPromote?.auto ?? DEFAULT_PROMOTE_CONFIG.auto,
       require_llm: rawPromote?.require_llm ?? DEFAULT_PROMOTE_CONFIG.require_llm,
-      min_confidence:
-        rawPromote?.min_confidence ?? DEFAULT_PROMOTE_CONFIG.min_confidence,
       project_keywords:
         rawPromote?.project_keywords ?? DEFAULT_PROMOTE_CONFIG.project_keywords,
       project_map_routing:

--- a/src/core/llm.ts
+++ b/src/core/llm.ts
@@ -27,9 +27,7 @@ export type VaultContext = {
 export type EnhancementSuggestions = {
   type?: string;
   description?: string;
-  links?: string[];
   project?: string[];
-  areas?: string[];
   reasoning?: string;
 };
 

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -12,15 +12,13 @@ Your job is to enhance a note that is being promoted from inbox to permanent sto
 Given a note's title, body, and frontmatter, plus context about the vault's existing notes:
 1. Suggest a better description (one sentence, max 200 chars, no trailing period)
 2. Classify the type: idea, decision, learning, insight, blocker, or opportunity
-3. Suggest wiki-links to existing notes that are relevant
-4. Suggest project tags if applicable
-5. Explain your reasoning briefly
+3. Suggest project tags if applicable
+4. Explain your reasoning briefly
 
 Respond with valid JSON matching this schema:
 {
   "type": "string (one of: idea, decision, learning, insight, blocker, opportunity)",
   "description": "string (one sentence, max 200 chars)",
-  "links": ["string array of existing note titles to link to"],
   "project": ["string array of project tags"],
   "reasoning": "string (brief explanation)"
 }
@@ -99,7 +97,6 @@ export class AnthropicProvider implements LlmProvider {
       if (typeof parsed.type === "string") result.type = parsed.type;
       if (typeof parsed.description === "string")
         result.description = parsed.description.slice(0, 200);
-      if (Array.isArray(parsed.links)) result.links = parsed.links;
       if (Array.isArray(parsed.project)) result.project = parsed.project;
       if (typeof parsed.reasoning === "string")
         result.reasoning = parsed.reasoning;

--- a/src/providers/openai-compat.ts
+++ b/src/providers/openai-compat.ts
@@ -12,15 +12,13 @@ Your job is to enhance a note that is being promoted from inbox to permanent sto
 Given a note's title, body, and frontmatter, plus context about the vault's existing notes:
 1. Suggest a better description (one sentence, max 200 chars, no trailing period)
 2. Classify the type: idea, decision, learning, insight, blocker, or opportunity
-3. Suggest wiki-links to existing notes that are relevant
-4. Suggest project tags if applicable
-5. Explain your reasoning briefly
+3. Suggest project tags if applicable
+4. Explain your reasoning briefly
 
 Respond with valid JSON matching this schema:
 {
   "type": "string (one of: idea, decision, learning, insight, blocker, opportunity)",
   "description": "string (one sentence, max 200 chars)",
-  "links": ["string array of existing note titles to link to"],
   "project": ["string array of project tags"],
   "reasoning": "string (brief explanation)"
 }
@@ -104,7 +102,6 @@ export class OpenAICompatProvider implements LlmProvider {
       if (typeof parsed.type === "string") result.type = parsed.type;
       if (typeof parsed.description === "string")
         result.description = parsed.description.slice(0, 200);
-      if (Array.isArray(parsed.links)) result.links = parsed.links;
       if (Array.isArray(parsed.project)) result.project = parsed.project;
       if (typeof parsed.reasoning === "string")
         result.reasoning = parsed.reasoning;

--- a/tests/core/promote-llm.test.ts
+++ b/tests/core/promote-llm.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runInit } from "../../src/cli/init.js";
+import { runPromote } from "../../src/cli/promote.js";
+import { parseFrontmatter } from "../../src/core/frontmatter.js";
+
+let tmpDir: string;
+
+async function writeInboxNote(name: string, body: string): Promise<void> {
+  const filePath = path.join(tmpDir, "inbox", `${name}.md`);
+  await fs.writeFile(
+    filePath,
+    [
+      "---",
+      'description: ""',
+      'type: ""',
+      "project: []",
+      "status: inbox",
+      "created: 2026-05-05",
+      "---",
+      "",
+      `# ${name.replace(/-/g, " ")}`,
+      "",
+      body,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+async function setConfig(search: string, replacement: string): Promise<void> {
+  const configPath = path.join(tmpDir, "ori.config.yaml");
+  const config = await fs.readFile(configPath, "utf8");
+  await fs.writeFile(configPath, config.replace(search, replacement), "utf8");
+}
+
+async function readPromotedFrontmatter(name: string): Promise<Record<string, unknown>> {
+  const content = await fs.readFile(path.join(tmpDir, "notes", `${name}.md`), "utf8");
+  return parseFrontmatter(content).data ?? {};
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "ori-promote-llm-"));
+  await runInit({ targetDir: tmpDir });
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  delete process.env.ORI_TEST_API_KEY;
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("runPromote LLM enhancement", () => {
+  it("promotes deterministically when LLM is not required and no provider is configured", async () => {
+    await writeInboxNote(
+      "deterministic-promote",
+      "This learned behavior should promote without an LLM provider.",
+    );
+
+    const result = await runPromote({ startDir: tmpDir, noteName: "deterministic-promote" });
+
+    expect(result.success).toBe(true);
+    expect(result.data.promoted).toHaveLength(1);
+    expect(result.data.skipped).toHaveLength(0);
+  });
+
+  it("skips promotion when require_llm is true and no provider is configured", async () => {
+    await setConfig("require_llm: false", "require_llm: true");
+    await writeInboxNote(
+      "llm-required",
+      "This note should not promote without an LLM provider.",
+    );
+
+    const result = await runPromote({ startDir: tmpDir, noteName: "llm-required" });
+
+    expect(result.success).toBe(true);
+    expect(result.data.promoted).toHaveLength(0);
+    expect(result.data.skipped).toEqual([
+      {
+        path: path.join(tmpDir, "inbox", "llm-required.md"),
+        reason: "LLM enhancement required but no provider is configured",
+      },
+    ]);
+  });
+
+  it("uses LLM type, description, and project suggestions when user overrides are absent", async () => {
+    process.env.ORI_TEST_API_KEY = "test-key";
+    await setConfig("provider: null", "provider: openai");
+    await setConfig("api_key_env: null", "api_key_env: ORI_TEST_API_KEY");
+    await writeInboxNote(
+      "llm-enhanced-note",
+      "We decided to change the memory boundary so agents can call from project folders.",
+    );
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{
+          message: {
+            content: JSON.stringify({
+              type: "decision",
+              description: "Vault-relative paths keep agent harnesses independent of vault layout",
+              project: ["cli"],
+              reasoning: "The note records an implementation decision.",
+            }),
+          },
+        }],
+      }),
+    } as Response);
+
+    const result = await runPromote({ startDir: tmpDir, noteName: "llm-enhanced-note" });
+    const frontmatter = await readPromotedFrontmatter("llm-enhanced-note");
+
+    expect(result.success).toBe(true);
+    expect(result.data.promoted).toHaveLength(1);
+    expect(frontmatter.type).toBe("decision");
+    expect(frontmatter.description).toBe(
+      "Vault-relative paths keep agent harnesses independent of vault layout",
+    );
+    expect(frontmatter.project).toEqual(["cli"]);
+  });
+
+  it("keeps user overrides above LLM suggestions", async () => {
+    process.env.ORI_TEST_API_KEY = "test-key";
+    await setConfig("provider: null", "provider: openai");
+    await setConfig("api_key_env: null", "api_key_env: ORI_TEST_API_KEY");
+    await writeInboxNote(
+      "override-priority-note",
+      "The model may suggest fields, but explicit caller choices should win.",
+    );
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{
+          message: {
+            content: JSON.stringify({
+              type: "learning",
+              description: "LLM description should not win",
+              project: ["llm-project"],
+            }),
+          },
+        }],
+      }),
+    } as Response);
+
+    const result = await runPromote({
+      startDir: tmpDir,
+      noteName: "override-priority-note",
+      type: "decision",
+      description: "Manual description should win",
+      project: ["manual-project"],
+    });
+    const frontmatter = await readPromotedFrontmatter("override-priority-note");
+
+    expect(result.success).toBe(true);
+    expect(frontmatter.type).toBe("decision");
+    expect(frontmatter.description).toBe("Manual description should win");
+    expect(frontmatter.project).toEqual(["manual-project"]);
+  });
+});


### PR DESCRIPTION
## Summary
- wire `enhance()` into `runPromote()` for type, description, and project suggestions
- preserve explicit user overrides above LLM suggestions
- keep `require_llm` as a hard gate when no provider is configured
- drop unused `min_confidence` promote config
- drop unsupported `areas` and LLM link suggestions from enhancement output
- trim provider prompts to the fields where LLM enhancement adds value

Fixes #18

## Tests
- `npm run build`
- `npx vitest run tests/core/promote-llm.test.ts --environment node`
- `npx vitest run tests/core/config.test.ts --environment node`