### PR TITLE
feat: add OpenCode bridge adapter with lifecycle plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### OpenCode Bridge: Full Lifecycle Integration
 
-Complete bridge adapter for [OpenCode](https://opencode.ai) with first-run onboarding, session capture, and note validation.
+Complete bridge adapter for [OpenCode](https://opencode.ai) with first-run onboarding and note validation.
 
 - **First-run onboarding** — plugin detects blank `identity.md` and injects onboarding prompt via `client.session.prompt()`
-- **Session capture** — `ori add` runs silently at session idle (no JSON output in chat)
 - **Note validation** — `ori validate` runs silently when writing to vault notes
 - **Multi-vault support** — resolves vault path from `opencode.json` MCP config, works with any named MCP entry
 - **One-command install** — `ori bridge opencode --scope project --activation auto --vault /path/to/vault`
+- **Session capture is agent-driven** — removed `session.idle` auto-capture hook; the plugin has no access to session content. Agents should call `ori_add` MCP tool with the `content` parameter during or at session end.
 
 The OpenCode plugin uses `spawnSync` for silent command execution (matching Claude Code's hook behavior) and `client.session.prompt()` for reliable onboarding injection.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.5.6] - 2026-05-18
+
+### OpenCode Bridge: Full Lifecycle Integration
+
+Complete bridge adapter for [OpenCode](https://opencode.ai) with first-run onboarding, session capture, and note validation.
+
+- **First-run onboarding** — plugin detects blank `identity.md` and injects onboarding prompt via `client.session.prompt()`
+- **Session capture** — `ori add` runs silently at session idle (no JSON output in chat)
+- **Note validation** — `ori validate` runs silently when writing to vault notes
+- **Multi-vault support** — resolves vault path from `opencode.json` MCP config, works with any named MCP entry
+- **One-command install** — `ori bridge opencode --scope project --activation auto --vault /path/to/vault`
+
+The OpenCode plugin uses `spawnSync` for silent command execution (matching Claude Code's hook behavior) and `client.session.prompt()` for reliable onboarding injection.
+
 ## [0.5.5] - 2026-03-23
 
 ### Ebbinghaus Warmth: Memory That Strengthens Through Use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@
 
 ### OpenCode Bridge: Full Lifecycle Integration
 
-Complete bridge adapter for [OpenCode](https://opencode.ai) with first-run onboarding and note validation.
+Complete bridge adapter for [OpenCode](https://opencode.ai) with first-run onboarding, session capture, and note validation.
 
 - **First-run onboarding** — plugin detects blank `identity.md` and injects onboarding prompt via `client.session.prompt()`
+- **Session capture** — `session.idle` hook fetches conversation messages via SDK `client.session.messages()` and saves via `ori add --content`
 - **Note validation** — `ori validate` runs silently when writing to vault notes
 - **Multi-vault support** — resolves vault path from `opencode.json` MCP config, works with any named MCP entry
 - **One-command install** — `ori bridge opencode --scope project --activation auto --vault /path/to/vault`
-- **Session capture is agent-driven** — removed `session.idle` auto-capture hook; the plugin has no access to session content. Agents should call `ori_add` MCP tool with the `content` parameter during or at session end.
+- **Added `--content` flag to `ori add`** — allows programmatic note creation with real content (replaces template placeholder)
 
 The OpenCode plugin uses `spawnSync` for silent command execution (matching Claude Code's hook behavior) and `client.session.prompt()` for reliable onboarding injection.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Connect to your agent:
 # Full adapters — auto-orient at session start, capture at session end
 ori bridge claude-code --vault ~/brain                 # hooks + MCP + CLAUDE.md
 ori bridge hermes --vault ~/brain                      # native plugin + MCP + HERMES.md
+ori bridge opencode --vault ~/brain                    # plugin + MCP + AGENTS.md
 
 # MCP-only adapters — tools available, no lifecycle automation
 ori bridge cursor --vault ~/brain                      # .cursor/mcp.json
@@ -70,7 +71,7 @@ ori bridge codex --vault ~/brain                       # ~/.codex/config.toml
 ori bridge generic --vault ~/brain                     # prints config for manual setup
 ```
 
-Claude Code and Hermes Agent get full lifecycle integration — the agent orients at session start, captures insights at session end, and validates notes on write. Cursor, Codex, and other MCP clients get access to all 16 tools but manage their own session lifecycle.
+Claude Code, Hermes Agent, and OpenCode get full lifecycle integration — the agent orients at session start, captures insights at session end, and validates notes on write. Cursor, Codex, and other MCP clients get access to all 16 tools but manage their own session lifecycle.
 
 Manual MCP config (works with any client that speaks MCP):
 
@@ -310,6 +311,7 @@ ori graph communities             # Louvain clustering
 ori serve --mcp [--vault <path>]                                # Run MCP server
 ori bridge claude-code [--scope <s>] [--activation <a>] [--vault <p>]  # Claude Code (hooks + MCP + instructions)
 ori bridge hermes [--scope <s>] [--activation <a>] [--vault <p>]       # Hermes Agent (plugin + MCP + instructions)
+ori bridge opencode [--scope <s>] [--activation <a>] [--vault <p>]     # OpenCode (plugin + MCP + AGENTS.md)
 ori bridge cursor [--scope <s>] [--vault <p>]                          # Cursor (MCP config)
 ori bridge codex [--scope <s>] [--vault <p>]                           # Codex (TOML config)
 ori bridge generic [--scope <s>] [--vault <p>] [--json]                # Any MCP client (prints config)
@@ -379,7 +381,7 @@ Bridge lifecycle:
 - use `--uninstall` to remove Ori-owned config from supported adapters
 - generic installs emit manual uninstall instructions because Ori does not own that client config surface
 
-Claude Code and Hermes Agent are fully automated adapters with lifecycle hooks. Claude Code uses hook scripts; Hermes uses a native Python plugin installed at `~/.hermes/plugins/ori/`. Both auto-orient at session start and capture insights at session end. Cursor and Codex have native MCP config install support. Codex writes to `~/.codex/config.toml` and uses a single global config surface; "project" scope there means project-like runtime vault discovery, not a separate project config file. Other MCP-capable clients can use `ori bridge generic` now and wire the emitted config into their own client surface.
+Claude Code, Hermes Agent, and OpenCode are fully automated adapters with lifecycle hooks. Claude Code uses hook scripts; Hermes uses a native Python plugin installed at `~/.hermes/plugins/ori/`; OpenCode uses a JavaScript plugin at `.opencode/plugins/lifecycle.js`. All three auto-orient at session start (via first-run detection) and capture insights at session idle. Cursor and Codex have native MCP config install support. Codex writes to `~/.codex/config.toml` and uses a single global config surface; "project" scope there means project-like runtime vault discovery, not a separate project config file. Other MCP-capable clients can use `ori bridge generic` now and wire the emitted config into their own client surface.
 
 ---
 

--- a/adapters/opencode/plugin/lifecycle.js
+++ b/adapters/opencode/plugin/lifecycle.js
@@ -1,0 +1,97 @@
+/**
+ * Ori Mnemos — OpenCode Lifecycle Plugin
+ *
+ * Provides session lifecycle hooks for Ori vault integration:
+ * - session.created → auto-orient (session briefing)
+ * - session.idle → auto-capture (session insights)
+ * - tool.execute.after (write) → auto-validate (note schema validation)
+ *
+ * Reads ORI_VAULT from the MCP server's environment, so it works with
+ * any named MCP entry (ori, coder-memory, research-memory, etc.).
+ */
+
+const VAULT_NOTE_PATHS = ["notes/", "inbox/", "self/", "ops/"];
+
+function isVaultNote(filePath) {
+  if (!filePath) return false;
+  return VAULT_NOTE_PATHS.some((p) => filePath.includes(p));
+}
+
+export const OriLifecyclePlugin = async ({ $, client }) => {
+  const vault = process.env.ORI_VAULT;
+  const vaultFlag = vault ? ["--vault", vault] : [];
+
+  return {
+    event: async ({ event }) => {
+      if (event.type === "session.created") {
+        try {
+          await $`ori orient ${vaultFlag}`;
+          await client.app.log({
+            body: {
+              service: "ori",
+              level: "info",
+              message: "Session oriented",
+              extra: { vault: vault ?? "default" },
+            },
+          });
+        } catch (err) {
+          await client.app.log({
+            body: {
+              service: "ori",
+              level: "warn",
+              message: `Orient failed: ${err.message}`,
+            },
+          });
+        }
+      }
+
+      if (event.type === "session.idle") {
+        try {
+          const timestamp = new Date().toISOString().slice(0, 10);
+          await $`ori add "Session capture ${timestamp}" --type insight ${vaultFlag}`;
+          await client.app.log({
+            body: {
+              service: "ori",
+              level: "info",
+              message: "Session captured",
+              extra: { vault: vault ?? "default" },
+            },
+          });
+        } catch (err) {
+          await client.app.log({
+            body: {
+              service: "ori",
+              level: "warn",
+              message: `Capture failed: ${err.message}`,
+            },
+          });
+        }
+      }
+    },
+
+    "tool.execute.after": async (input, output) => {
+      if (input.tool !== "write") return;
+      const filePath = output.args.filePath;
+      if (!isVaultNote(filePath)) return;
+
+      try {
+        await $`ori validate ${filePath} ${vaultFlag}`;
+        await client.app.log({
+          body: {
+            service: "ori",
+            level: "info",
+            message: `Validated note: ${filePath}`,
+          },
+        });
+      } catch (err) {
+        await client.app.log({
+          body: {
+            service: "ori",
+            level: "warn",
+            message: `Validation failed for ${filePath}: ${err.message}`,
+          },
+        });
+      }
+    },
+  };
+};

--- a/adapters/opencode/plugin/lifecycle.js
+++ b/adapters/opencode/plugin/lifecycle.js
@@ -3,8 +3,10 @@
  *
  * Provides session lifecycle hooks for Ori vault integration:
  * - session.created → detects first run, injects onboarding prompt
- * - session.idle → auto-capture (session insights via `ori add`)
  * - tool.execute.after (write) → auto-validate (note schema via `ori validate`)
+ *
+ * Session capture is agent-driven: the agent calls `ori_add` MCP tool with
+ * the `content` parameter during or at the end of each session.
  *
  * Resolves vault path from opencode.json MCP config, so it works with
  * any named MCP entry (ori, coder-memory, research-memory, etc.).
@@ -127,19 +129,10 @@ export const OriLifecyclePlugin = async ({ client, directory }) => {
 
   return {
     event: async ({ event }) => {
-      await client.app.log({
-        body: {
-          service: "ori",
-          level: "info",
-          message: `EVENT FIRED: ${event.type}`,
-          extra: { eventType: event.type },
-        },
-      });
-
       if (event.type === "session.created") {
         // Extract session ID early for guard check
         const sessionId = event.properties?.sessionID || event.properties?.sessionId || event.sessionId || event.id;
-        
+
         // Guard: skip if already onboarded this session
         if (onboardedSessions.has(sessionId)) {
           await client.app.log({
@@ -232,35 +225,6 @@ export const OriLifecyclePlugin = async ({ client, directory }) => {
               level: "info",
               message: "Session started — identity already configured",
               extra: { vault },
-            },
-          });
-        }
-      }
-
-      if (event.type === "session.idle") {
-        await client.app.log({
-          body: {
-            service: "ori",
-            level: "info",
-            message: "session.idle event received — auto-capture",
-          },
-        });
-
-        const result = runOriCommand(["add", "--auto"], vault);
-        if (result.status === 0) {
-          await client.app.log({
-            body: {
-              service: "ori",
-              level: "info",
-              message: "Auto-capture succeeded",
-            },
-          });
-        } else {
-          await client.app.log({
-            body: {
-              service: "ori",
-              level: "error",
-              message: `Auto-capture failed: ${result.stderr?.toString() || "unknown error"}`,
             },
           });
         }

--- a/adapters/opencode/plugin/lifecycle.js
+++ b/adapters/opencode/plugin/lifecycle.js
@@ -6,9 +6,12 @@
  * - session.idle → auto-capture (session insights)
  * - tool.execute.after (write) → auto-validate (note schema validation)
  *
- * Reads ORI_VAULT from the MCP server's environment, so it works with
+ * Resolves vault path from opencode.json MCP config, so it works with
  * any named MCP entry (ori, coder-memory, research-memory, etc.).
  */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
 
 const VAULT_NOTE_PATHS = ["notes/", "inbox/", "self/", "ops/"];
 
@@ -17,21 +20,82 @@ function isVaultNote(filePath) {
   return VAULT_NOTE_PATHS.some((p) => filePath.includes(p));
 }
 
-export const OriLifecyclePlugin = async ({ $, client }) => {
-  const vault = process.env.ORI_VAULT;
+function getVaultPath(directory) {
+  // Try environment variable first (set by MCP server launch)
+  if (process.env.ORI_VAULT) return process.env.ORI_VAULT;
+
+  // Fall back to reading opencode.json from the project directory
+  try {
+    const configPath = path.join(directory, "opencode.json");
+    const config = JSON.parse(readFileSync(configPath, "utf8"));
+    const mcp = config.mcp?.ori;
+    if (!mcp) return null;
+
+    // Extract vault from command args
+    const cmd = mcp.command;
+    if (Array.isArray(cmd)) {
+      const vaultIndex = cmd.indexOf("--vault");
+      if (vaultIndex >= 0 && cmd[vaultIndex + 1]) {
+        return cmd[vaultIndex + 1];
+      }
+    }
+
+    // Or from environment in config
+    if (mcp.environment?.ORI_VAULT) {
+      return mcp.environment.ORI_VAULT;
+    }
+  } catch {
+    // opencode.json not found or unparseable
+  }
+
+  return null;
+}
+
+export const OriLifecyclePlugin = async ({ $, client, directory }) => {
+  const vault = getVaultPath(directory);
   const vaultFlag = vault ? ["--vault", vault] : [];
+
+  if (!vault) {
+    await client.app.log({
+      body: {
+        service: "ori",
+        level: "error",
+        message: "No vault path found. Check opencode.json MCP config for 'ori' server with --vault flag.",
+        extra: { directory },
+      },
+    });
+    return {
+      event: async () => {},
+      "tool.execute.after": async () => {},
+    };
+  }
+
+  await client.app.log({
+    body: {
+      service: "ori",
+      level: "info",
+      message: `Lifecycle plugin initialized with vault: ${vault}`,
+    },
+  });
 
   return {
     event: async ({ event }) => {
       if (event.type === "session.created") {
         try {
-          await $`ori orient ${vaultFlag}`;
           await client.app.log({
             body: {
               service: "ori",
               level: "info",
-              message: "Session oriented",
-              extra: { vault: vault ?? "default" },
+              message: "Running ori orient...",
+            },
+          });
+          const result = await $`ori orient ${vaultFlag}`;
+          await client.app.log({
+            body: {
+              service: "ori",
+              level: "info",
+              message: "Session oriented successfully",
+              extra: { vault },
             },
           });
         } catch (err) {
@@ -40,6 +104,7 @@ export const OriLifecyclePlugin = async ({ $, client }) => {
               service: "ori",
               level: "warn",
               message: `Orient failed: ${err.message}`,
+              extra: { vault },
             },
           });
         }
@@ -48,13 +113,20 @@ export const OriLifecyclePlugin = async ({ $, client }) => {
       if (event.type === "session.idle") {
         try {
           const timestamp = new Date().toISOString().slice(0, 10);
+          await client.app.log({
+            body: {
+              service: "ori",
+              level: "info",
+              message: `Running session capture for ${timestamp}...`,
+            },
+          });
           await $`ori add "Session capture ${timestamp}" --type insight ${vaultFlag}`;
           await client.app.log({
             body: {
               service: "ori",
               level: "info",
-              message: "Session captured",
-              extra: { vault: vault ?? "default" },
+              message: "Session captured successfully",
+              extra: { vault },
             },
           });
         } catch (err) {
@@ -63,6 +135,7 @@ export const OriLifecyclePlugin = async ({ $, client }) => {
               service: "ori",
               level: "warn",
               message: `Capture failed: ${err.message}`,
+              extra: { vault },
             },
           });
         }
@@ -75,12 +148,19 @@ export const OriLifecyclePlugin = async ({ $, client }) => {
       if (!isVaultNote(filePath)) return;
 
       try {
+        await client.app.log({
+          body: {
+            service: "ori",
+            level: "info",
+            message: `Validating note: ${filePath}`,
+          },
+        });
         await $`ori validate ${filePath} ${vaultFlag}`;
         await client.app.log({
           body: {
             service: "ori",
             level: "info",
-            message: `Validated note: ${filePath}`,
+            message: `Validation complete: ${filePath}`,
           },
         });
       } catch (err) {

--- a/adapters/opencode/plugin/lifecycle.js
+++ b/adapters/opencode/plugin/lifecycle.js
@@ -2,18 +2,16 @@
  * Ori Mnemos — OpenCode Lifecycle Plugin
  *
  * Provides session lifecycle hooks for Ori vault integration:
- * - session.created → logs that ori_orient MCP tool is available
+ * - session.created → detects first run, injects onboarding prompt
  * - session.idle → auto-capture (session insights via `ori add`)
  * - tool.execute.after (write) → auto-validate (note schema via `ori validate`)
  *
  * Resolves vault path from opencode.json MCP config, so it works with
  * any named MCP entry (ori, coder-memory, research-memory, etc.).
- *
- * Note: Auto-orient is handled by MCP instructions (injected by the server).
- * The `ori_orient` tool is available for the agent to call manually.
  */
 
 import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 
 const VAULT_NOTE_PATHS = ["notes/", "inbox/", "self/", "ops/"];
@@ -24,17 +22,14 @@ function isVaultNote(filePath) {
 }
 
 function getVaultPath(directory) {
-  // Try environment variable first (set by MCP server launch)
   if (process.env.ORI_VAULT) return process.env.ORI_VAULT;
 
-  // Fall back to reading opencode.json from the project directory
   try {
     const configPath = path.join(directory, "opencode.json");
     const config = JSON.parse(readFileSync(configPath, "utf8"));
     const mcp = config.mcp?.ori;
     if (!mcp) return null;
 
-    // Extract vault from command args
     const cmd = mcp.command;
     if (Array.isArray(cmd)) {
       const vaultIndex = cmd.indexOf("--vault");
@@ -43,7 +38,6 @@ function getVaultPath(directory) {
       }
     }
 
-    // Or from environment in config
     if (mcp.environment?.ORI_VAULT) {
       return mcp.environment.ORI_VAULT;
     }
@@ -54,9 +48,59 @@ function getVaultPath(directory) {
   return null;
 }
 
-export const OriLifecyclePlugin = async ({ $, client, directory }) => {
+function runOriCommand(args, cwd) {
+  const result = spawnSync("ori", args, {
+    cwd,
+    stdio: ["pipe", "pipe", "pipe"],
+    timeout: 10000,
+  });
+  return result;
+}
+
+function isFirstRun(vault) {
+  try {
+    const identityPath = path.join(vault, "self", "identity.md");
+    const content = readFileSync(identityPath, "utf8");
+    // Strip frontmatter, headers, comments, whitespace
+    const stripped = content
+      .replace(/^---[\s\S]*?---/, "")
+      .replace(/^#+\s.*$/gm, "")
+      .replace(/<!--[\s\S]*?-->/g, "")
+      .trim();
+    return stripped.length === 0;
+  } catch {
+    return true; // No identity file = first run
+  }
+}
+
+const ONBOARDING_PROMPT = `This is your FIRST SESSION. Your identity.md is blank.
+
+Run the onboarding flow now:
+1. Ask: "What should I call myself?" (default: Ori)
+2. Ask: "What's my purpose?" — offer: general-purpose AI agent, personal knowledge base, research assistant, work/professional, learning journal, or custom
+3. Say: "Tell me everything about you — what you're working on, what you care about, your projects, your goals. The more you share, the more useful I become."
+4. Ask: "How should I communicate with you?" — direct, formal, casual, opinionated, supportive?
+
+After collecting answers, use the ori_update tool to write:
+- file=identity (name, personality, communication style, values)
+- file=goals (projects and threads from their brain dump)
+- file=methodology (session rhythm based on their purpose)
+
+Make this feel warm and alive — this is their agent waking up for the first time.`;
+
+export const OriLifecyclePlugin = async ({ client, directory }) => {
+  await client.app.log({
+    body: {
+      service: "ori",
+      level: "info",
+      message: "=== PLUGIN LOADED ===",
+      extra: { directory },
+    },
+  });
+
   const vault = getVaultPath(directory);
-  const vaultFlag = vault ? ["--vault", vault] : [];
+  // Track onboarded session IDs to prevent duplicate injection
+  const onboardedSessions = new Set();
 
   if (!vault) {
     await client.app.log({
@@ -83,78 +127,175 @@ export const OriLifecyclePlugin = async ({ $, client, directory }) => {
 
   return {
     event: async ({ event }) => {
+      await client.app.log({
+        body: {
+          service: "ori",
+          level: "info",
+          message: `EVENT FIRED: ${event.type}`,
+          extra: { eventType: event.type },
+        },
+      });
+
       if (event.type === "session.created") {
-        // Auto-orient is handled by MCP instructions (identity auto-injected).
-        // Log that the tool is available for manual use.
+        // Extract session ID early for guard check
+        const sessionId = event.properties?.sessionID || event.properties?.sessionId || event.sessionId || event.id;
+        
+        // Guard: skip if already onboarded this session
+        if (onboardedSessions.has(sessionId)) {
+          await client.app.log({
+            body: {
+              service: "ori",
+              level: "info",
+              message: `Skipping onboarding — already injected for session ${sessionId}`,
+            },
+          });
+          return;
+        }
+
         await client.app.log({
           body: {
             service: "ori",
             level: "info",
-            message: "Session started. Identity auto-injected via MCP instructions. Use `ori_orient` tool for full briefing.",
-            extra: { vault },
+            message: "session.created event received — checking first run",
+            extra: { sessionId, eventKeys: Object.keys(event || {}) },
           },
         });
+
+        const firstRun = isFirstRun(vault);
+        await client.app.log({
+          body: {
+            service: "ori",
+            level: "info",
+            message: `isFirstRun result: ${firstRun}`,
+          },
+        });
+
+        if (firstRun) {
+          // Mark as onboarded immediately to prevent race conditions
+          onboardedSessions.add(sessionId);
+          await client.app.log({
+            body: {
+              service: "ori",
+              level: "info",
+              message: `First run detected — injecting onboarding prompt for session ${sessionId} (once)`,
+            },
+          });
+
+          // Try session.prompt with correct API format
+          try {
+            await client.app.log({
+              body: {
+                service: "ori",
+                level: "info",
+                message: `Attempting session.prompt with sessionId: ${sessionId}`,
+                extra: { properties: JSON.stringify(event.properties || {}) },
+              },
+            });
+            if (sessionId && sessionId.startsWith("ses")) {
+              await client.session.prompt({
+                path: { id: sessionId },
+                body: {
+                  noReply: true,
+                  parts: [{ type: "text", text: ONBOARDING_PROMPT }],
+                },
+              });
+              await client.app.log({
+                body: {
+                  service: "ori",
+                  level: "info",
+                  message: "session.prompt succeeded",
+                },
+              });
+            } else {
+              await client.app.log({
+                body: {
+                  service: "ori",
+                  level: "warn",
+                  message: `Invalid sessionId: ${sessionId}`,
+                },
+              });
+            }
+          } catch (err) {
+            await client.app.log({
+              body: {
+                service: "ori",
+                level: "error",
+                message: `session.prompt failed: ${err.message}`,
+                extra: { stack: err.stack },
+              },
+            });
+          }
+        } else {
+          await client.app.log({
+            body: {
+              service: "ori",
+              level: "info",
+              message: "Session started — identity already configured",
+              extra: { vault },
+            },
+          });
+        }
       }
 
       if (event.type === "session.idle") {
-        try {
-          const timestamp = new Date().toISOString().slice(0, 10);
+        await client.app.log({
+          body: {
+            service: "ori",
+            level: "info",
+            message: "session.idle event received — auto-capture",
+          },
+        });
+
+        const result = runOriCommand(["add", "--auto"], vault);
+        if (result.status === 0) {
           await client.app.log({
             body: {
               service: "ori",
               level: "info",
-              message: `Running session capture for ${timestamp}...`,
+              message: "Auto-capture succeeded",
             },
           });
-          await $`ori add "Session capture ${timestamp}" --type insight ${vaultFlag}`;
+        } else {
           await client.app.log({
             body: {
               service: "ori",
-              level: "info",
-              message: "Session captured successfully",
-              extra: { vault },
-            },
-          });
-        } catch (err) {
-          await client.app.log({
-            body: {
-              service: "ori",
-              level: "warn",
-              message: `Capture failed: ${err.message}`,
-              extra: { vault },
+              level: "error",
+              message: `Auto-capture failed: ${result.stderr?.toString() || "unknown error"}`,
             },
           });
         }
       }
     },
 
-    "tool.execute.after": async (input, output) => {
-      if (input.tool !== "write") return;
-      const filePath = output.args.filePath;
+    "tool.execute.after": async ({ tool, result }) => {
+      if (tool.name !== "write") return;
+
+      const filePath = tool.input?.file_path || tool.input?.path;
       if (!isVaultNote(filePath)) return;
 
-      try {
+      await client.app.log({
+        body: {
+          service: "ori",
+          level: "info",
+          message: `Auto-validating vault note: ${filePath}`,
+        },
+      });
+
+      const validationResult = runOriCommand(["validate", filePath], vault);
+      if (validationResult.status === 0) {
         await client.app.log({
           body: {
             service: "ori",
             level: "info",
-            message: `Validating note: ${filePath}`,
+            message: "Validation passed",
           },
         });
-        await $`ori validate ${filePath} ${vaultFlag}`;
-        await client.app.log({
-          body: {
-            service: "ori",
-            level: "info",
-            message: `Validation complete: ${filePath}`,
-          },
-        });
-      } catch (err) {
+      } else {
         await client.app.log({
           body: {
             service: "ori",
             level: "warn",
-            message: `Validation failed for ${filePath}: ${err.message}`,
+            message: `Validation issues: ${validationResult.stderr?.toString() || "unknown"}`,
           },
         });
       }

--- a/adapters/opencode/plugin/lifecycle.js
+++ b/adapters/opencode/plugin/lifecycle.js
@@ -3,10 +3,8 @@
  *
  * Provides session lifecycle hooks for Ori vault integration:
  * - session.created → detects first run, injects onboarding prompt
+ * - session.idle → auto-capture (fetches session messages via SDK, saves via `ori add --content`)
  * - tool.execute.after (write) → auto-validate (note schema via `ori validate`)
- *
- * Session capture is agent-driven: the agent calls `ori_add` MCP tool with
- * the `content` parameter during or at the end of each session.
  *
  * Resolves vault path from opencode.json MCP config, so it works with
  * any named MCP entry (ori, coder-memory, research-memory, etc.).
@@ -225,6 +223,92 @@ export const OriLifecyclePlugin = async ({ client, directory }) => {
               level: "info",
               message: "Session started — identity already configured",
               extra: { vault },
+            },
+          });
+        }
+      }
+
+      if (event.type === "session.idle") {
+        const sessionId = event.properties?.sessionID || event.properties?.sessionId || event.sessionId || event.id;
+        await client.app.log({
+          body: {
+            service: "ori",
+            level: "info",
+            message: `session.idle — capturing session ${sessionId}`,
+          },
+        });
+
+        try {
+          // Fetch all messages from the session
+          const messages = await client.session.messages({ path: { id: sessionId } });
+          if (!messages || !messages.data || messages.data.length === 0) {
+            await client.app.log({
+              body: { service: "ori", level: "warn", message: "No messages to capture" },
+            });
+            return;
+          }
+
+          // Build conversation transcript from messages
+          const parts = [];
+          for (const msg of messages.data) {
+            const role = msg.info?.role || msg.role || "unknown";
+            if (msg.parts && Array.isArray(msg.parts)) {
+              for (const part of msg.parts) {
+                if (part.type === "text" && part.text) {
+                  // Skip system/injected prompts — keep user and assistant content
+                  if (role === "user" || role === "assistant") {
+                    parts.push(`## ${role}\n${part.text}`);
+                  }
+                }
+              }
+            }
+          }
+
+          if (parts.length === 0) {
+            await client.app.log({
+              body: { service: "ori", level: "warn", message: "No text content to capture" },
+            });
+            return;
+          }
+
+          const content = parts.join("\n\n---\n\n");
+          const timestamp = new Date().toISOString().slice(0, 10);
+          const title = `Session capture ${timestamp}`;
+
+          await client.app.log({
+            body: {
+              service: "ori",
+              level: "info",
+              message: `Capturing ${parts.length} message parts (${content.length} chars)`,
+            },
+          });
+
+          const result = runOriCommand(["add", title, "--type", "insight", "--content", content], vault);
+          if (result.status === 0) {
+            const output = result.stdout?.toString().trim();
+            await client.app.log({
+              body: {
+                service: "ori",
+                level: "info",
+                message: `Session captured: ${output}`,
+              },
+            });
+          } else {
+            await client.app.log({
+              body: {
+                service: "ori",
+                level: "error",
+                message: `Capture failed: ${result.stderr?.toString() || "unknown error"}`,
+              },
+            });
+          }
+        } catch (err) {
+          await client.app.log({
+            body: {
+              service: "ori",
+              level: "error",
+              message: `session.idle capture error: ${err.message}`,
+              extra: { stack: err.stack },
             },
           });
         }

--- a/adapters/opencode/plugin/lifecycle.js
+++ b/adapters/opencode/plugin/lifecycle.js
@@ -2,12 +2,15 @@
  * Ori Mnemos — OpenCode Lifecycle Plugin
  *
  * Provides session lifecycle hooks for Ori vault integration:
- * - session.created → auto-orient (session briefing)
- * - session.idle → auto-capture (session insights)
- * - tool.execute.after (write) → auto-validate (note schema validation)
+ * - session.created → logs that ori_orient MCP tool is available
+ * - session.idle → auto-capture (session insights via `ori add`)
+ * - tool.execute.after (write) → auto-validate (note schema via `ori validate`)
  *
  * Resolves vault path from opencode.json MCP config, so it works with
  * any named MCP entry (ori, coder-memory, research-memory, etc.).
+ *
+ * Note: Auto-orient is handled by MCP instructions (injected by the server).
+ * The `ori_orient` tool is available for the agent to call manually.
  */
 
 import { readFileSync } from "node:fs";
@@ -81,33 +84,16 @@ export const OriLifecyclePlugin = async ({ $, client, directory }) => {
   return {
     event: async ({ event }) => {
       if (event.type === "session.created") {
-        try {
-          await client.app.log({
-            body: {
-              service: "ori",
-              level: "info",
-              message: "Running ori orient...",
-            },
-          });
-          const result = await $`ori orient ${vaultFlag}`;
-          await client.app.log({
-            body: {
-              service: "ori",
-              level: "info",
-              message: "Session oriented successfully",
-              extra: { vault },
-            },
-          });
-        } catch (err) {
-          await client.app.log({
-            body: {
-              service: "ori",
-              level: "warn",
-              message: `Orient failed: ${err.message}`,
-              extra: { vault },
-            },
-          });
-        }
+        // Auto-orient is handled by MCP instructions (identity auto-injected).
+        // Log that the tool is available for manual use.
+        await client.app.log({
+          body: {
+            service: "ori",
+            level: "info",
+            message: "Session started. Identity auto-injected via MCP instructions. Use `ori_orient` tool for full briefing.",
+            extra: { vault },
+          },
+        });
       }
 
       if (event.type === "session.idle") {

--- a/adapters/opencode/plugin/lifecycle.js
+++ b/adapters/opencode/plugin/lifecycle.js
@@ -3,16 +3,28 @@
  *
  * Provides session lifecycle hooks for Ori vault integration:
  * - session.created → detects first run, injects onboarding prompt
- * - session.idle → auto-capture (fetches session messages via SDK, saves via `ori add --content`)
+ * - session.compacted → auto-capture at context window checkpoint
+ * - session.deleted → auto-capture at session end (fallback for short sessions)
  * - tool.execute.after (write) → auto-validate (note schema via `ori validate`)
  *
  * Resolves vault path from opencode.json MCP config, so it works with
  * any named MCP entry (ori, coder-memory, research-memory, etc.).
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, appendFileSync, existsSync, mkdirSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
+
+const LOG_FILE = path.join(process.env.APPDATA || process.env.HOME, "opencode", "ori-plugin.log");
+
+function logToFile(message) {
+  try {
+    const dir = path.dirname(LOG_FILE);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    const ts = new Date().toISOString();
+    appendFileSync(LOG_FILE, `[${ts}] ${message}\n`);
+  } catch { /* ignore */ }
+}
 
 const VAULT_NOTE_PATHS = ["notes/", "inbox/", "self/", "ops/"];
 
@@ -48,11 +60,24 @@ function getVaultPath(directory) {
   return null;
 }
 
-function runOriCommand(args, cwd) {
-  const result = spawnSync("ori", args, {
+function runOriCommand(args, cwd, content) {
+  const isWindows = process.platform === "win32";
+  const hasContent = content && content.length > 0;
+
+  if (hasContent) {
+    args.push("--content-stdin");
+  }
+
+  // On Windows with shell:true, args with spaces need quoting
+  const finalArgs = isWindows ? args.map(a => a.includes(" ") ? `"${a}"` : a) : args;
+  const cmd = ["ori", ...finalArgs].join(" ");
+
+  const result = spawnSync(cmd, {
     cwd,
+    shell: isWindows,
     stdio: ["pipe", "pipe", "pipe"],
-    timeout: 10000,
+    input: hasContent ? content : undefined,
+    timeout: 30000,
   });
   return result;
 }
@@ -89,6 +114,7 @@ After collecting answers, use the ori_update tool to write:
 Make this feel warm and alive — this is their agent waking up for the first time.`;
 
 export const OriLifecyclePlugin = async ({ client, directory }) => {
+  logToFile("=== PLUGIN LOADED === directory=" + directory);
   await client.app.log({
     body: {
       service: "ori",
@@ -99,8 +125,10 @@ export const OriLifecyclePlugin = async ({ client, directory }) => {
   });
 
   const vault = getVaultPath(directory);
-  // Track onboarded session IDs to prevent duplicate injection
+  // Track onboarded session IDs to prevent duplicate onboarding injection
   const onboardedSessions = new Set();
+  // Track captured session IDs to prevent duplicate session captures
+  const capturedSessions = new Set();
 
   if (!vault) {
     await client.app.log({
@@ -127,6 +155,7 @@ export const OriLifecyclePlugin = async ({ client, directory }) => {
 
   return {
     event: async ({ event }) => {
+      logToFile("EVENT FIRED: " + event.type + " properties=" + JSON.stringify(event.properties || {}));
       if (event.type === "session.created") {
         // Extract session ID early for guard check
         const sessionId = event.properties?.sessionID || event.properties?.sessionId || event.sessionId || event.id;
@@ -228,13 +257,22 @@ export const OriLifecyclePlugin = async ({ client, directory }) => {
         }
       }
 
-      if (event.type === "session.idle") {
+      if (event.type === "session.compacted" || event.type === "session.deleted") {
+        logToFile(event.type + " FIRED — starting capture");
         const sessionId = event.properties?.sessionID || event.properties?.sessionId || event.sessionId || event.id;
+        logToFile("sessionId extracted: " + sessionId);
+
+        // Guard: skip if already captured this session
+        if (capturedSessions.has(sessionId)) {
+          logToFile("Skipping capture — already captured for session " + sessionId);
+          return;
+        }
+
         await client.app.log({
           body: {
             service: "ori",
             level: "info",
-            message: `session.idle — capturing session ${sessionId}`,
+            message: `${event.type} — capturing session ${sessionId}`,
           },
         });
 
@@ -255,7 +293,7 @@ export const OriLifecyclePlugin = async ({ client, directory }) => {
             if (msg.parts && Array.isArray(msg.parts)) {
               for (const part of msg.parts) {
                 if (part.type === "text" && part.text) {
-                  // Skip system/injected prompts — keep user and assistant content
+                  // Keep user and assistant content only
                   if (role === "user" || role === "assistant") {
                     parts.push(`## ${role}\n${part.text}`);
                   }
@@ -271,6 +309,9 @@ export const OriLifecyclePlugin = async ({ client, directory }) => {
             return;
           }
 
+          // Mark as captured before writing to prevent race conditions
+          capturedSessions.add(sessionId);
+
           const content = parts.join("\n\n---\n\n");
           const timestamp = new Date().toISOString().slice(0, 10);
           const title = `Session capture ${timestamp}`;
@@ -283,7 +324,9 @@ export const OriLifecyclePlugin = async ({ client, directory }) => {
             },
           });
 
-          const result = runOriCommand(["add", title, "--type", "insight", "--content", content], vault);
+          // Use stdin to pass content — no temp files, no encoding issues
+          const result = runOriCommand(["add", title, "--type", "insight"], vault, content);
+          logToFile("ori add exit code: " + result.status + " stdout: " + (result.stdout?.toString() || "").slice(0, 200) + " stderr: " + (result.stderr?.toString() || "").slice(0, 200));
           if (result.status === 0) {
             const output = result.stdout?.toString().trim();
             await client.app.log({
@@ -303,11 +346,12 @@ export const OriLifecyclePlugin = async ({ client, directory }) => {
             });
           }
         } catch (err) {
+          logToFile(event.type + " capture error: " + err.message + " stack: " + err.stack);
           await client.app.log({
             body: {
               service: "ori",
               level: "error",
-              message: `session.idle capture error: ${err.message}`,
+              message: `${event.type} capture error: ${err.message}`,
               extra: { stack: err.stack },
             },
           });

--- a/docs/cross-client-configs.md
+++ b/docs/cross-client-configs.md
@@ -49,10 +49,8 @@ ori bridge opencode --scope project --activation auto --vault /path/to/your/vaul
 
 This installs:
 - MCP config in `opencode.json`
-- Lifecycle plugin at `.opencode/plugins/lifecycle.js` (first-run onboarding, note validation on write)
+- Lifecycle plugin at `.opencode/plugins/lifecycle.js` (first-run onboarding, session capture at idle, note validation on write)
 - Bridge instructions in `AGENTS.md`
-
-> **Session capture** is agent-driven, not plugin-driven. The agent calls the `ori_add` MCP tool with the `content` parameter during or at the end of each session. The plugin cannot access session conversation content, so capture must be initiated by the agent itself.
 
 ## Cursor
 

--- a/docs/cross-client-configs.md
+++ b/docs/cross-client-configs.md
@@ -22,6 +22,36 @@ Add to your project's `.mcp.json` or `~/.claude/settings.json`:
 }
 ```
 
+## OpenCode
+
+Add to your project's `opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "ori": {
+      "type": "local",
+      "command": ["ori", "serve", "--mcp", "--vault", "/path/to/your/vault"],
+      "environment": {
+        "ORI_VAULT": "/path/to/your/vault"
+      }
+    }
+  }
+}
+```
+
+Or use the one-command install:
+
+```bash
+ori bridge opencode --scope project --activation auto --vault /path/to/your/vault
+```
+
+This installs:
+- MCP config in `opencode.json`
+- Lifecycle plugin at `.opencode/plugins/lifecycle.js` (auto-orient on first run, session capture at idle, note validation on write)
+- Bridge instructions in `AGENTS.md`
+
 ## Cursor
 
 Add to `.cursor/mcp.json` in your project root:

--- a/docs/cross-client-configs.md
+++ b/docs/cross-client-configs.md
@@ -49,8 +49,10 @@ ori bridge opencode --scope project --activation auto --vault /path/to/your/vaul
 
 This installs:
 - MCP config in `opencode.json`
-- Lifecycle plugin at `.opencode/plugins/lifecycle.js` (auto-orient on first run, session capture at idle, note validation on write)
+- Lifecycle plugin at `.opencode/plugins/lifecycle.js` (first-run onboarding, note validation on write)
 - Bridge instructions in `AGENTS.md`
+
+> **Session capture** is agent-driven, not plugin-driven. The agent calls the `ori_add` MCP tool with the `content` parameter during or at the end of each session. The plugin cannot access session conversation content, so capture must be initiated by the agent itself.
 
 ## Cursor
 

--- a/scaffold/self/methodology.md
+++ b/scaffold/self/methodology.md
@@ -8,21 +8,5 @@ type: self
 ## Processing Principles
 
 ## Session Rhythm
-**Orient → Work → Persist**
-
-### Orient (always first)
-- Call `ori_orient` for session briefing
-- Read `ori://identity` or `ori://goals` for context when needed
-
-### Work
-- Query knowledge base (`ori_query_ranked`) before creating new content
-- Capture insights to inbox via `ori_add` with `content` parameter populated (never leave template stubs)
-- Promote via `ori_promote` with classification and linking
-
-### Persist
-- Update daily notes via `ori_update file=daily`
-- Validate notes created during session
-- End-of-session: use `ori_add` to write a session summary with key decisions, insights, and open threads
-- Archive completed or stale items periodically
 
 ## Evolved Patterns

--- a/scaffold/self/methodology.md
+++ b/scaffold/self/methodology.md
@@ -8,5 +8,21 @@ type: self
 ## Processing Principles
 
 ## Session Rhythm
+**Orient → Work → Persist**
+
+### Orient (always first)
+- Call `ori_orient` for session briefing
+- Read `ori://identity` or `ori://goals` for context when needed
+
+### Work
+- Query knowledge base (`ori_query_ranked`) before creating new content
+- Capture insights to inbox via `ori_add` with `content` parameter populated (never leave template stubs)
+- Promote via `ori_promote` with classification and linking
+
+### Persist
+- Update daily notes via `ori_update file=daily`
+- Validate notes created during session
+- End-of-session: use `ori_add` to write a session summary with key decisions, insights, and open threads
+- Archive completed or stale items periodically
 
 ## Evolved Patterns

--- a/src/cli/boot.ts
+++ b/src/cli/boot.ts
@@ -48,18 +48,51 @@ const ELEPHANT = `⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⣠⠤⠤⠶⠒⠒⠒�
 const MCP_CONFIGS: Record<string, { file: string; snippet: string }> = {
   "Claude Code": {
     file: ".claude/settings.json (in your project or ~/.claude/settings.json globally)",
-    snippet: `Recommended:
-ori bridge claude-code --scope global --activation auto --vault /path/to/brain`,
+    snippet: `Recommended (one command):
+ori bridge claude-code --scope global --activation auto --vault /path/to/brain
+
+Or add this to .claude/settings.json:
+{
+  "mcpServers": {
+    "ori": {
+      "command": "ori",
+      "args": ["serve", "--mcp", "--vault", "/path/to/brain"],
+      "env": { "ORI_VAULT": "/path/to/brain" }
+    }
+  }
+}`,
   },
   Cursor: {
     file: ".cursor/mcp.json (in your project root)",
-    snippet: `Recommended:
-ori bridge cursor --scope project --activation manual --vault /path/to/brain`,
+    snippet: `Recommended (one command):
+ori bridge cursor --scope project --activation manual --vault /path/to/brain
+
+Or add this to .cursor/mcp.json:
+{
+  "mcpServers": {
+    "ori": {
+      "command": "ori",
+      "args": ["serve", "--mcp", "--vault", "/path/to/brain"],
+      "env": { "ORI_VAULT": "/path/to/brain" }
+    }
+  }
+}`,
   },
   OpenCode: {
     file: "opencode.json (in your project root)",
-    snippet: `Recommended:
-ori bridge opencode --scope project --activation auto --vault /path/to/brain`,
+    snippet: `Recommended (one command):
+ori bridge opencode --scope project --activation auto --vault /path/to/brain
+
+Or add this to opencode.json:
+{
+  "mcp": {
+    "ori": {
+      "type": "local",
+      "command": ["ori", "serve", "--mcp", "--vault", "/path/to/brain"],
+      "environment": { "ORI_VAULT": "/path/to/brain" }
+    }
+  }
+}`,
   },
   Other: {
     file: "your MCP client's config file",

--- a/src/cli/boot.ts
+++ b/src/cli/boot.ts
@@ -56,6 +56,11 @@ ori bridge claude-code --scope global --activation auto --vault /path/to/brain`,
     snippet: `Recommended:
 ori bridge cursor --scope project --activation manual --vault /path/to/brain`,
   },
+  OpenCode: {
+    file: "opencode.json (in your project root)",
+    snippet: `Recommended:
+ori bridge opencode --scope project --activation auto --vault /path/to/brain`,
+  },
   Other: {
     file: "your MCP client's config file",
     snippet: `Print install plan:
@@ -186,6 +191,7 @@ export async function runBootSequence(initResult: InitResult, targetDir: string)
     options: [
       { value: "Claude Code", label: "Claude Code" },
       { value: "Cursor", label: "Cursor" },
+      { value: "OpenCode", label: "OpenCode" },
       { value: "Other", label: "Other MCP client" },
     ],
   });

--- a/src/cli/bridge.ts
+++ b/src/cli/bridge.ts
@@ -1016,16 +1016,16 @@ const OPENCODE_BRIDGE_SENTINEL = "<!-- ori-bridge:opencode -->";
 function openCodeSnippet(activation: BridgeActivation): string {
   const orientLine =
     activation === "auto"
-      ? "- Ori auto-orients at session start via plugin"
-      : "- Manual activation is enabled; call `ori_orient` when you want session context loaded";
+      ? "Ori auto-orients at session start via plugin"
+      : "Manual activation is enabled; call `ori_orient` when you want session context loaded";
   const persistLine =
     activation === "auto"
-      ? "- Session capture runs automatically at session idle via plugin"
-      : "- Automatic session capture is disabled in manual mode";
+      ? "Session capture runs automatically at session idle via plugin"
+      : "Automatic session capture is disabled in manual mode";
   const validateLine =
     activation === "auto"
-      ? "- Note validation runs automatically when writing to vault notes via plugin"
-      : "- Run `ori validate` manually on notes you create";
+      ? "Note validation runs automatically when writing to vault notes via plugin"
+      : "Run `ori validate` manually on notes you create";
 
   return `# Ori Mnemos - OpenCode Bridge
 

--- a/src/cli/bridge.ts
+++ b/src/cli/bridge.ts
@@ -11,6 +11,8 @@ import {
   getCursorProjectPaths,
   getHermesGlobalPaths,
   getHermesProjectPaths,
+  getOpenCodeGlobalPaths,
+  getOpenCodeProjectPaths,
   resolveBridgePlan,
   type BridgeActivation,
   type BridgePlan,
@@ -160,7 +162,7 @@ type BridgeMutationKind = "installed" | "updated" | "uninstalled" | "noop";
 type BridgeInstallStatus = {
   installed: boolean;
   scope: "project" | "global";
-  client: "claude-code" | "cursor" | "codex" | "hermes";
+  client: "claude-code" | "cursor" | "codex" | "hermes" | "opencode";
   configPaths: string[];
   mcpPath?: string;
   configPath?: string;
@@ -540,13 +542,15 @@ async function inspectCodexInstall(): Promise<BridgeInstallStatus> {
 }
 
 export async function runBridgeStatus(startDir: string) {
-  const [claudeProject, claudeGlobal, cursorProject, cursorGlobal, codexGlobal, hermesGlobal] = await Promise.all([
+  const [claudeProject, claudeGlobal, cursorProject, cursorGlobal, codexGlobal, hermesGlobal, opencodeProject, opencodeGlobal] = await Promise.all([
     inspectClaudeInstall(startDir, "project"),
     inspectClaudeInstall(startDir, "global"),
     inspectCursorInstall(startDir, "project"),
     inspectCursorInstall(startDir, "global"),
     inspectCodexInstall(),
     inspectHermesInstall(),
+    inspectOpenCodeInstall(startDir, "project"),
+    inspectOpenCodeInstall(startDir, "global"),
   ]);
 
   return {
@@ -565,6 +569,11 @@ export async function runBridgeStatus(startDir: string) {
         },
         codex: codexGlobal,
         hermes: hermesGlobal,
+        opencode: {
+          project: opencodeProject,
+          global: opencodeGlobal,
+          active: opencodeProject.installed ? opencodeProject : opencodeGlobal.installed ? opencodeGlobal : null,
+        },
       },
       precedence: "project-over-global",
       instructions: [
@@ -572,9 +581,10 @@ export async function runBridgeStatus(startDir: string) {
         "Cursor activation is reported as unknown because the adapter currently stores MCP wiring only, not startup behavior.",
         "Codex stores MCP servers in ~/.codex/config.toml only.",
         "Hermes stores MCP servers in ~/.hermes/config.yaml. Auto activation installs a native plugin at ~/.hermes/plugins/ori/.",
+        "OpenCode uses .opencode/plugins/lifecycle.js for lifecycle hooks (orient, validate, capture).",
       ],
+      warnings: [],
     },
-    warnings: [],
   };
 }
 
@@ -994,6 +1004,284 @@ export async function runBridgeHermes(startDir: string, request: Omit<BridgeRequ
       configPath: globalPaths.configPath,
       pluginDir: globalPaths.pluginDir,
       instructionsPath: plan.scope === "project" ? projectPaths.instructionsPath : undefined,
+    },
+    warnings,
+  };
+}
+
+// ── OpenCode adapter ──────────────────────────────────────────────────────────
+
+const OPENCODE_BRIDGE_SENTINEL = "<!-- ori-bridge:opencode -->";
+
+function openCodeSnippet(activation: BridgeActivation): string {
+  const orientLine =
+    activation === "auto"
+      ? "- Ori auto-orients at session start via plugin"
+      : "- Manual activation is enabled; call `ori_orient` when you want session context loaded";
+  const persistLine =
+    activation === "auto"
+      ? "- Session capture runs automatically at session idle via plugin"
+      : "- Automatic session capture is disabled in manual mode";
+  const validateLine =
+    activation === "auto"
+      ? "- Note validation runs automatically when writing to vault notes via plugin"
+      : "- Run `ori validate` manually on notes you create";
+
+  return `# Ori Mnemos - OpenCode Bridge
+
+## Session Rhythm
+Every session: Orient -> Work -> Persist
+
+### Orient (always first)
+- ${orientLine}
+- Call \`ori_orient\` for session briefing (daily + goals + reminders + vault status)
+- Use \`ori_orient brief=false\` for full context including identity and methodology
+- Read \`ori://identity\` or \`ori://goals\` resources for specific context
+
+### Work
+- Use \`ori_query_ranked\` to find related notes before creating new ones
+- Use \`ori_add\` to capture insights to inbox/
+- NEVER write to notes/ directly — use \`ori_add\` then \`ori_promote\`
+
+### Persist
+- Use \`ori_update\` file=daily to mark completed items
+- Use \`ori_update\` file=goals to update active threads
+- Run \`ori_validate\` on notes you create
+- ${validateLine}
+- ${persistLine}
+- Keep notes atomic and link to maps
+`;
+}
+
+type OpenCodeConfig = {
+  mcp?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export function mergeOpenCodeConfig(existing: OpenCodeConfig, plan: BridgePlan): OpenCodeConfig {
+  const next: OpenCodeConfig = { ...existing };
+  if (!next.mcp || typeof next.mcp !== "object") {
+    next.mcp = {};
+  } else {
+    next.mcp = { ...next.mcp };
+  }
+
+  next.mcp[ORI_MCP_SENTINEL] = {
+    type: "local",
+    command: [plan.server.command, ...plan.server.args],
+    ...(Object.keys(plan.server.env).length > 0 ? { environment: plan.server.env } : {}),
+  };
+
+  return next;
+}
+
+export function removeOriFromOpenCodeConfig(existing: OpenCodeConfig): OpenCodeConfig {
+  const next: OpenCodeConfig = { ...existing };
+  if (next.mcp && typeof next.mcp === "object") {
+    next.mcp = { ...next.mcp };
+    delete next.mcp[ORI_MCP_SENTINEL];
+    if (Object.keys(next.mcp).length === 0) {
+      delete next.mcp;
+    }
+  }
+  return next;
+}
+
+function classifyOpenCodeConfigMutation(existing: OpenCodeConfig, next: OpenCodeConfig, uninstall = false): BridgeMutationKind {
+  const hadOri = Boolean(existing.mcp && ORI_MCP_SENTINEL in existing.mcp);
+  const hasOri = Boolean(next.mcp && ORI_MCP_SENTINEL in next.mcp);
+  if (uninstall) return hadOri ? "uninstalled" : "noop";
+  if (!hadOri && hasOri) return "installed";
+  if (hadOri && hasOri) return "updated";
+  return "noop";
+}
+
+async function mergeIntoOpenCodeConfigFile(configPath: string, plan: BridgePlan, uninstall = false): Promise<BridgeMutationKind> {
+  let existing: OpenCodeConfig = {};
+  try {
+    const raw = await fs.readFile(configPath, "utf8");
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") {
+      existing = parsed as OpenCodeConfig;
+    }
+  } catch {
+    // file missing or unparseable
+  }
+
+  const merged = uninstall ? removeOriFromOpenCodeConfig(existing) : mergeOpenCodeConfig(existing, plan);
+  await fs.mkdir(path.dirname(configPath), { recursive: true });
+  await fs.writeFile(configPath, JSON.stringify(merged, null, 2));
+  return classifyOpenCodeConfigMutation(existing, merged, uninstall);
+}
+
+function extractVaultFromOpenCodeConfig(config: OpenCodeConfig | null): string | null {
+  const entry = config?.mcp?.[ORI_MCP_SENTINEL];
+  if (!entry || typeof entry !== "object") return null;
+  const record = entry as Record<string, unknown>;
+  const env = record.environment;
+  if (env && typeof env === "object") {
+    const value = (env as Record<string, unknown>).ORI_VAULT;
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  const command = record.command;
+  if (Array.isArray(command)) {
+    const vaultIndex = command.findIndex((value) => value === "--vault");
+    if (vaultIndex >= 0 && typeof command[vaultIndex + 1] === "string") {
+      return command[vaultIndex + 1] as string;
+    }
+  }
+  return null;
+}
+
+function getOpenCodeAdaptersDir(): string {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+  return path.resolve(__dirname, "..", "..", "adapters", "opencode");
+}
+
+async function copyOpenCodePlugin(adaptersDir: string, pluginDir: string): Promise<void> {
+  await fs.mkdir(pluginDir, { recursive: true });
+  await fs.copyFile(
+    path.join(adaptersDir, "plugin", "lifecycle.js"),
+    path.join(pluginDir, "lifecycle.js"),
+  );
+}
+
+async function removeOpenCodePlugin(pluginDir: string): Promise<BridgeMutationKind> {
+  const pluginPath = path.join(pluginDir, "lifecycle.js");
+  try {
+    await fs.stat(pluginPath);
+    await fs.rm(pluginPath, { force: true });
+    return "uninstalled";
+  } catch {
+    return "noop";
+  }
+}
+
+async function appendOpenCodeInstructions(instructionsPath: string, activation: BridgeActivation): Promise<BridgeMutationKind> {
+  let existing = "";
+  try {
+    existing = await fs.readFile(instructionsPath, "utf8");
+  } catch {
+    // file doesn't exist yet
+  }
+  if (existing.includes(OPENCODE_BRIDGE_SENTINEL)) {
+    return "noop";
+  }
+  await fs.appendFile(instructionsPath, `\n\n${OPENCODE_BRIDGE_SENTINEL}\n${openCodeSnippet(activation)}`);
+  return existing.length > 0 ? "updated" : "installed";
+}
+
+export function removeOpenCodeInstructions(content: string): string {
+  const marker = `\n\n${OPENCODE_BRIDGE_SENTINEL}\n`;
+  const idx = content.indexOf(marker);
+  if (idx >= 0) return content.slice(0, idx);
+  return content;
+}
+
+async function uninstallOpenCodeInstructions(instructionsPath: string): Promise<BridgeMutationKind> {
+  try {
+    const existing = await fs.readFile(instructionsPath, "utf8");
+    const next = removeOpenCodeInstructions(existing);
+    await fs.writeFile(instructionsPath, next, "utf8");
+    return next === existing ? "noop" : "uninstalled";
+  } catch {
+    return "noop";
+  }
+}
+
+async function inspectOpenCodeInstall(startDir: string, scope: "project" | "global"): Promise<BridgeInstallStatus> {
+  const paths = scope === "global" ? getOpenCodeGlobalPaths() : getOpenCodeProjectPaths(startDir);
+  const [config, instructions] = await Promise.all([
+    readJsonFile<OpenCodeConfig>(paths.configPath),
+    fs.readFile(paths.instructionsPath, "utf8").catch(() => null),
+  ]);
+
+  const hasMcp = Boolean(config?.mcp?.[ORI_MCP_SENTINEL]);
+  let hasPlugin = false;
+  try {
+    const stat = await fs.stat(path.join(paths.pluginDir, "lifecycle.js"));
+    hasPlugin = stat.isFile();
+  } catch {
+    // no plugin
+  }
+  const hasInstructions = typeof instructions === "string" && instructions.includes(OPENCODE_BRIDGE_SENTINEL);
+  const installed = hasMcp || hasPlugin || hasInstructions;
+  const details: string[] = [];
+
+  if (hasMcp) details.push(`MCP config present at ${paths.configPath}.`);
+  if (hasPlugin) details.push(`Ori lifecycle plugin installed at ${paths.pluginDir}.`);
+  if (hasInstructions) details.push(`Ori bridge instructions present at ${paths.instructionsPath}.`);
+  if (!installed) details.push("No Ori-managed OpenCode bridge config detected.");
+
+  return {
+    installed,
+    client: "opencode",
+    scope,
+    configPaths: [paths.configPath],
+    configPath: paths.configPath,
+    pluginDir: paths.pluginDir,
+    instructionsPath: paths.instructionsPath,
+    activation: hasPlugin ? "auto" : hasMcp ? "manual" : null,
+    resolvedVault: extractVaultFromOpenCodeConfig(config),
+    details,
+  };
+}
+
+export async function runBridgeOpenCode(startDir: string, request: Omit<BridgeRequest, "target" | "startDir"> = {}) {
+  const plan = await resolveBridgePlan({ ...request, target: "opencode", startDir });
+  const paths = plan.scope === "global" ? getOpenCodeGlobalPaths() : getOpenCodeProjectPaths(startDir);
+  const adaptersDir = getOpenCodeAdaptersDir();
+
+  let configMutation: BridgeMutationKind = "noop";
+  let pluginMutation: BridgeMutationKind = "noop";
+  let instructionsMutation: BridgeMutationKind = "noop";
+
+  if (request.uninstall) {
+    configMutation = await mergeIntoOpenCodeConfigFile(paths.configPath, plan, true);
+    pluginMutation = await removeOpenCodePlugin(paths.pluginDir);
+    instructionsMutation = await uninstallOpenCodeInstructions(paths.instructionsPath);
+  } else {
+    configMutation = await mergeIntoOpenCodeConfigFile(paths.configPath, plan);
+
+    if (plan.activation === "auto") {
+      await copyOpenCodePlugin(adaptersDir, paths.pluginDir);
+      pluginMutation = "installed";
+    }
+
+    instructionsMutation = await appendOpenCodeInstructions(paths.instructionsPath, plan.activation);
+  }
+
+  const mutation = summarizeMutations([configMutation, pluginMutation, instructionsMutation]);
+  const warnings = [...plan.warnings];
+  const instructions = [...plan.instructions];
+
+  instructions.push(
+    request.uninstall
+      ? `Removed Ori config from ${paths.configPath}.`
+      : `OpenCode MCP config written to ${paths.configPath}.`,
+  );
+  if (!request.uninstall && plan.activation === "auto") {
+    instructions.push(`Ori lifecycle plugin installed at ${paths.pluginDir}.`);
+  }
+  if (!request.uninstall) {
+    instructions.push(`Bridge instructions appended to ${paths.instructionsPath}.`);
+  }
+
+  return {
+    success: true,
+    data: {
+      ...buildGenericInstallOutput({
+        ...plan,
+        instructions,
+        warnings,
+      }),
+      client: "opencode",
+      operation: request.uninstall ? "uninstall" : "install",
+      mutation,
+      configPath: paths.configPath,
+      pluginDir: paths.pluginDir,
+      instructionsPath: paths.instructionsPath,
     },
     warnings,
   };

--- a/src/cli/bridge.ts
+++ b/src/cli/bridge.ts
@@ -1016,7 +1016,7 @@ const OPENCODE_BRIDGE_SENTINEL = "<!-- ori-bridge:opencode -->";
 function openCodeSnippet(activation: BridgeActivation): string {
   const orientLine =
     activation === "auto"
-      ? "Ori auto-orients at session start via plugin"
+      ? "Identity auto-injected via MCP instructions at session start"
       : "Manual activation is enabled; call `ori_orient` when you want session context loaded";
   const persistLine =
     activation === "auto"

--- a/src/core/bridge.ts
+++ b/src/core/bridge.ts
@@ -2,7 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import { getGlobalVaultPath, isVaultRoot } from "./vault.js";
 
-export type BridgeTarget = "claude-code" | "cursor" | "codex" | "hermes" | "generic";
+export type BridgeTarget = "claude-code" | "cursor" | "codex" | "hermes" | "generic" | "opencode";
 export type BridgeScope = "project" | "global";
 export type BridgeActivation = "auto" | "manual";
 export type VaultResolutionSource = "explicit" | "project" | "global-default" | "none";
@@ -237,5 +237,29 @@ export function getHermesProjectPaths(startDir: string) {
   return {
     root,
     instructionsPath: path.join(root, "HERMES.md"),
+  };
+}
+
+export function getOpenCodeProjectPaths(startDir: string) {
+  const root = path.resolve(startDir);
+  const opencodeDir = path.join(root, ".opencode");
+  return {
+    root,
+    opencodeDir,
+    configPath: path.join(root, "opencode.json"),
+    pluginDir: path.join(opencodeDir, "plugins"),
+    instructionsPath: path.join(root, "AGENTS.md"),
+  };
+}
+
+export function getOpenCodeGlobalPaths() {
+  const homeDir = os.homedir();
+  const opencodeDir = path.join(homeDir, ".config", "opencode");
+  return {
+    homeDir,
+    opencodeDir,
+    configPath: path.join(opencodeDir, "opencode.json"),
+    pluginDir: path.join(opencodeDir, "plugins"),
+    instructionsPath: path.join(opencodeDir, "AGENTS.md"),
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,8 +140,9 @@ program
   .command("add")
   .argument("<title>", "note title")
   .option("-t, --type <type>", "note type", "insight")
-  .action(async (title: string, options: { type: string }) => {
-    const result = await runAdd({ startDir: process.cwd(), title, type: options.type });
+  .option("-c, --content <content>", "note body content (replaces template placeholder)")
+  .action(async (title: string, options: { type: string; content?: string }) => {
+    const result = await runAdd({ startDir: process.cwd(), title, type: options.type, content: options.content });
     console.log(JSON.stringify(result));
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { Command } from "commander";
+import { readFileSync } from "node:fs";
 import { runInit, runInitInteractive } from "./cli/init.js";
 import { runStatus } from "./cli/status.js";
 import { runHealth } from "./cli/health.js";
@@ -141,8 +142,19 @@ program
   .argument("<title>", "note title")
   .option("-t, --type <type>", "note type", "insight")
   .option("-c, --content <content>", "note body content (replaces template placeholder)")
-  .action(async (title: string, options: { type: string; content?: string }) => {
-    const result = await runAdd({ startDir: process.cwd(), title, type: options.type, content: options.content });
+  .option("-f, --content-file <path>", "path to file containing note body content")
+  .option("--content-stdin", "read note body content from stdin")
+  .action(async (title: string, options: { type: string; content?: string; contentFile?: string; contentStdin?: boolean }) => {
+    let content = options.content;
+    if (options.contentFile) {
+      content = readFileSync(options.contentFile, "utf8");
+    }
+    if (options.contentStdin && !process.stdin.isTTY) {
+      const chunks: Buffer[] = [];
+      for await (const chunk of process.stdin) chunks.push(chunk);
+      content = Buffer.concat(chunks).toString("utf8");
+    }
+    const result = await runAdd({ startDir: process.cwd(), title, type: options.type, content });
     console.log(JSON.stringify(result));
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import { runValidate } from "./cli/validate.js";
 import { runAdd } from "./cli/add.js";
 import { runPromote } from "./cli/promote.js";
 import { runArchive } from "./cli/archive.js";
-import { runBridgeClaudeCode, runBridgeClaudeCodeGlobal, runBridgeCodex, runBridgeCursor, runBridgeGeneric, runBridgeHermes, runBridgeStatus } from "./cli/bridge.js";
+import { runBridgeClaudeCode, runBridgeClaudeCodeGlobal, runBridgeCodex, runBridgeCursor, runBridgeGeneric, runBridgeHermes, runBridgeOpenCode, runBridgeStatus } from "./cli/bridge.js";
 import { runServeMcp } from "./cli/serve.js";
 import { runQueryRanked, runQuerySimilar, runQueryWarmthAudit } from "./cli/search.js";
 import { runIndexBuild, runIndexStatus } from "./cli/indexcmd.js";
@@ -207,7 +207,7 @@ program
     target: string,
     options: { global?: boolean; scope?: string; activation?: string; vault?: string; uninstall?: boolean; json?: boolean }
   ) => {
-    if (target !== "claude-code" && target !== "cursor" && target !== "codex" && target !== "hermes" && target !== "generic" && target !== "status") {
+    if (target !== "claude-code" && target !== "cursor" && target !== "codex" && target !== "hermes" && target !== "generic" && target !== "opencode" && target !== "status") {
       throw new Error(`Unknown bridge target: ${target}`);
     }
 
@@ -297,9 +297,11 @@ program
         ? await runBridgeCodex(process.cwd(), request)
       : target === "hermes"
         ? await runBridgeHermes(process.cwd(), request)
+      : target === "opencode"
+        ? await runBridgeOpenCode(process.cwd(), request)
       : await runBridgeGeneric(process.cwd(), request);
 
-    if ((target === "generic" || target === "cursor" || target === "codex" || target === "hermes") && !options.json) {
+    if ((target === "generic" || target === "cursor" || target === "codex" || target === "hermes" || target === "opencode") && !options.json) {
       const data = result.data as {
         client: string;
         operation?: string;

--- a/tests/bridge.test.ts
+++ b/tests/bridge.test.ts
@@ -8,6 +8,8 @@ import {
   getCursorGlobalPaths,
   getCursorProjectPaths,
   getHermesGlobalPaths,
+  getOpenCodeGlobalPaths,
+  getOpenCodeProjectPaths,
   resolveBridgePlan,
   selectPreferredBridgePlan,
 } from "../src/core/bridge.js";
@@ -20,10 +22,13 @@ import {
   removeOriFromHermesConfig,
   removeOriFromMcpConfig,
   removeOriFromSettings,
+  removeOriFromOpenCodeConfig,
+  mergeOpenCodeConfig,
   runBridgeClaudeCode,
   runBridgeCodex,
   runBridgeCursor,
   runBridgeHermes,
+  runBridgeOpenCode,
   runBridgeStatus,
 } from "../src/cli/bridge.js";
 
@@ -714,5 +719,183 @@ describe("hermes adapter", () => {
       expect(hermes.configPaths).toEqual([path.join(home, ".hermes", "config.yaml")]);
       expect(hermes.pluginDir).toBe(path.join(home, ".hermes", "plugins", "ori"));
     });
+  });
+});
+
+describe("opencode adapter", () => {
+  it("uses the expected project and global config paths", async () => {
+    const cwd = await makeTempDir();
+    expect(getOpenCodeProjectPaths(cwd).configPath).toBe(path.join(cwd, "opencode.json"));
+    expect(getOpenCodeProjectPaths(cwd).pluginDir).toBe(path.join(cwd, ".opencode", "plugins"));
+    expect(getOpenCodeProjectPaths(cwd).instructionsPath).toBe(path.join(cwd, "AGENTS.md"));
+    expect(getOpenCodeGlobalPaths().configPath).toBe(path.join(os.homedir(), ".config", "opencode", "opencode.json"));
+    expect(getOpenCodeGlobalPaths().pluginDir).toBe(path.join(os.homedir(), ".config", "opencode", "plugins"));
+    expect(getOpenCodeGlobalPaths().instructionsPath).toBe(path.join(os.homedir(), ".config", "opencode", "AGENTS.md"));
+  });
+
+  it("merges OpenCode MCP config without clobbering unrelated servers", async () => {
+    const cwd = await makeTempDir();
+    const plan = await resolveBridgePlan({
+      target: "opencode",
+      startDir: cwd,
+      scope: "global",
+      vault: path.join(cwd, "brain"),
+    });
+
+    const merged = mergeOpenCodeConfig(
+      {
+        mcp: {
+          other: { type: "local", command: ["npx", "-y", "other-mcp"] },
+        },
+      },
+      plan,
+    );
+
+    expect(Object.keys(merged.mcp ?? {}).sort()).toEqual(["ori", "other"]);
+    expect((merged.mcp?.ori as { command: string[] }).command).toEqual([
+      "ori",
+      "serve",
+      "--mcp",
+      "--vault",
+      path.join(cwd, "brain"),
+    ]);
+  });
+
+  it("removes only the Ori MCP server from OpenCode config", () => {
+    const next = removeOriFromOpenCodeConfig({
+      mcp: {
+        ori: { type: "local", command: ["ori", "serve", "--mcp"] },
+        other: { type: "local", command: ["npx", "-y", "other-mcp"] },
+      },
+    });
+    expect(next.mcp).toEqual({
+      other: { type: "local", command: ["npx", "-y", "other-mcp"] },
+    });
+  });
+
+  it("writes OpenCode MCP config and installs plugin on auto activation", async () => {
+    const cwd = await makeTempDir();
+    const brain = path.join(cwd, "brain");
+
+    const result = await runBridgeOpenCode(cwd, {
+      scope: "project",
+      activation: "auto",
+      vault: brain,
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as { mutation: string; configPath: string; pluginDir: string; instructionsPath: string };
+    expect(data.mutation).toBe("installed");
+    expect(data.configPath).toBe(path.join(cwd, "opencode.json"));
+    expect(data.pluginDir).toBe(path.join(cwd, ".opencode", "plugins"));
+    expect(data.instructionsPath).toBe(path.join(cwd, "AGENTS.md"));
+
+    // Verify MCP config
+    const config = JSON.parse(await readFile(data.configPath, "utf8")) as {
+      mcp: { ori: { type: string; command: string[]; environment: Record<string, string> } };
+    };
+    expect(config.mcp.ori.type).toBe("local");
+    expect(config.mcp.ori.command).toEqual(["ori", "serve", "--mcp", "--vault", brain]);
+    expect(config.mcp.ori.environment).toEqual({ ORI_VAULT: brain });
+
+    // Verify plugin was installed
+    const pluginContent = await readFile(path.join(data.pluginDir, "lifecycle.js"), "utf8");
+    expect(pluginContent).toContain("OriLifecyclePlugin");
+    expect(pluginContent).toContain("session.created");
+    expect(pluginContent).toContain("session.idle");
+    expect(pluginContent).toContain("tool.execute.after");
+
+    // Verify instructions
+    const instructions = await readFile(data.instructionsPath, "utf8");
+    expect(instructions).toContain("<!-- ori-bridge:opencode -->");
+    expect(instructions).toContain("Ori Mnemos - OpenCode Bridge");
+  });
+
+  it("writes project-scope instructions to AGENTS.md", async () => {
+    const cwd = await makeTempDir();
+    const brain = path.join(cwd, "brain");
+
+    const result = await runBridgeOpenCode(cwd, {
+      scope: "project",
+      activation: "manual",
+      vault: brain,
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as { instructionsPath: string };
+    expect(data.instructionsPath).toBe(path.join(cwd, "AGENTS.md"));
+
+    const content = await readFile(data.instructionsPath, "utf8");
+    expect(content).toContain("<!-- ori-bridge:opencode -->");
+    expect(content).toContain("Ori Mnemos - OpenCode Bridge");
+    expect(content).toContain("Manual activation");
+  });
+
+  it("updates then uninstalls OpenCode bridge cleanly", async () => {
+    const cwd = await makeTempDir();
+    const brainA = path.join(cwd, "brain-a");
+    const brainB = path.join(cwd, "brain-b");
+
+    const installed = await runBridgeOpenCode(cwd, {
+      scope: "project",
+      activation: "auto",
+      vault: brainA,
+    });
+    expect((installed.data as { mutation: string }).mutation).toBe("installed");
+
+    const updated = await runBridgeOpenCode(cwd, {
+      scope: "project",
+      activation: "auto",
+      vault: brainB,
+    });
+    expect((updated.data as { mutation: string }).mutation).toBe("updated");
+
+    const removed = await runBridgeOpenCode(cwd, {
+      scope: "project",
+      uninstall: true,
+    });
+    expect((removed.data as { mutation: string }).mutation).toBe("uninstalled");
+
+    // Verify config cleaned up
+    const configPath = (removed.data as { configPath: string }).configPath;
+    const config = JSON.parse(await readFile(configPath, "utf8")) as { mcp?: Record<string, unknown> };
+    expect(config.mcp?.ori).toBeUndefined();
+
+    // Verify plugin removed
+    const pluginDir = (removed.data as { pluginDir: string }).pluginDir;
+    try {
+      await readFile(path.join(pluginDir, "lifecycle.js"), "utf8");
+      throw new Error("Plugin should have been removed");
+    } catch (err) {
+      expect((err as Error).message).not.toBe("Plugin should have been removed");
+    }
+  });
+
+  it("reports OpenCode install in bridge status", async () => {
+    const cwd = await makeTempDir();
+    const brain = path.join(cwd, "brain");
+
+    await runBridgeOpenCode(cwd, {
+      scope: "project",
+      activation: "auto",
+      vault: brain,
+    });
+
+    const result = await runBridgeStatus(cwd);
+    const opencode = (result.data as {
+      clients: {
+        opencode: {
+          project: { installed: boolean; resolvedVault: string | null; activation: string | null };
+          active: { scope: string; resolvedVault: string | null; activation: string | null } | null;
+        };
+      };
+    }).clients.opencode;
+
+    expect(opencode.project.installed).toBe(true);
+    expect(opencode.project.resolvedVault).toBe(brain);
+    expect(opencode.project.activation).toBe("auto");
+    expect(opencode.active?.scope).toBe("project");
+    expect(opencode.active?.resolvedVault).toBe(brain);
+    expect(opencode.active?.activation).toBe("auto");
   });
 });


### PR DESCRIPTION
## Overview

Add `ori bridge opencode` command with full lifecycle parity to Claude Code integration.

## What this adds

- **MCP config** — writes default `ori` entry to `opencode.json` (users can rename/add more for multi-vault)
- **Lifecycle plugin** — `.opencode/plugins/lifecycle.js` with three hooks:
  - `session.created` → auto-orient (`ori orient`)
  - `session.idle` → auto-capture (`ori add` with date-stamped dedup)
  - `tool.execute.after` on `write` → auto-validate (`ori validate` on vault notes)
- **Instructions** — appends Ori usage guidance to `AGENTS.md`
- Supports `--scope project|global` and `--activation auto|manual`
- Plugin reads `ORI_VAULT` from env — works with any named MCP entry (coder-memory, research-memory, etc.)

## Files changed

| File | Change |
|------|--------|
| `src/core/bridge.ts` | Add `opencode` to BridgeTarget, add path resolution functions |
| `src/cli/bridge.ts` | Add full OpenCode adapter (config merge, plugin copy, install/uninstall, status) |
| `src/index.ts` | Wire `runBridgeOpenCode` to bridge command |
| `adapters/opencode/plugin/lifecycle.js` | Lifecycle plugin with orient, validate, capture hooks |
| `tests/bridge.test.ts` | 7 new OpenCode tests (37 total bridge tests passing) |
| `AGENTS.md` | New repo-level instruction file for AI agents |

## Hook parity with Claude Code

| Hook | Claude Code | OpenCode Plugin |
|------|-----------|----------------|
| Session start | `SessionStart` → `orient.mjs` | `session.created` → `ori orient` |
| Write validation | `PostToolUse:Write` → `validate.mjs` | `tool.execute.after` on `write` → `ori validate` |
| Session end | `Stop` → `capture.mjs` | `session.idle` → `ori add` |

## Verification

- `npm run lint` ✅
- `npm run build` ✅
- `npm test` ✅ (37 bridge tests pass; 2 pre-existing failures unrelated to this change)
