### PR TITLE
test: stabilize local suite hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ CLAUDE.md
 PLAN.md
 ROADMAP.md
 tests/*
+!tests/e2e/
+tests/e2e/*
+!tests/e2e/auto-init.test.ts
 !tests/bridge.test.ts
 !tests/cli/
 tests/cli/*
@@ -48,6 +51,8 @@ tests/core/*
 !tests/core/stage-learner.test.ts
 !tests/core/dampening.test.ts
 !tests/core/classify.test.ts
+!tests/core/activation.test.ts
+!tests/core/vault.test.ts
 !tests/core/vault-path.test.ts
 !tests/core/promote-llm.test.ts
 !tests/mcp/

--- a/tests/core/activation.test.ts
+++ b/tests/core/activation.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import Database from "better-sqlite3";
+import {
+  computeActivationSpread,
+  loadBoosts,
+  applyActivationBoosts,
+  DEFAULT_ACTIVATION_CONFIG,
+} from "../../src/core/activation.js";
+import type { LinkGraph } from "../../src/core/graph.js";
+import { initDB } from "../../src/core/engine.js";
+
+// ---------------------------------------------------------------------------
+// Helper: build a simple link graph from edge list
+// ---------------------------------------------------------------------------
+
+function makeGraph(edges: Array<[string, string]>): LinkGraph {
+  const outgoing = new Map<string, Set<string>>();
+  const incoming = new Map<string, Set<string>>();
+
+  for (const [source, target] of edges) {
+    if (!outgoing.has(source)) outgoing.set(source, new Set());
+    outgoing.get(source)!.add(target);
+    if (!incoming.has(target)) incoming.set(target, new Set());
+    incoming.get(target)!.add(source);
+  }
+
+  return { outgoing, incoming };
+}
+
+// ---------------------------------------------------------------------------
+// computeActivationSpread
+// ---------------------------------------------------------------------------
+
+describe("computeActivationSpread", () => {
+  it("linear chain A→B→C: B gets u×0.6, C gets u×0.36", () => {
+    const graph = makeGraph([["A", "B"], ["B", "C"]]);
+    const result = computeActivationSpread("A", 1.0, graph);
+
+    expect(result.propagated.get("B")).toBeCloseTo(0.6, 6);
+    expect(result.propagated.get("C")).toBeCloseTo(0.36, 6);
+    expect(result.propagated.has("A")).toBe(false); // no self-boost
+  });
+
+  it("star graph A→{B,C,D}: all get u×0.6", () => {
+    const graph = makeGraph([["A", "B"], ["A", "C"], ["A", "D"]]);
+    const result = computeActivationSpread("A", 1.0, graph);
+
+    expect(result.propagated.get("B")).toBeCloseTo(0.6, 6);
+    expect(result.propagated.get("C")).toBeCloseTo(0.6, 6);
+    expect(result.propagated.get("D")).toBeCloseTo(0.6, 6);
+  });
+
+  it("max hops: 3-hop neighbor gets nothing with max_hops=2", () => {
+    const graph = makeGraph([["A", "B"], ["B", "C"], ["C", "D"]]);
+    const result = computeActivationSpread("A", 1.0, graph);
+
+    expect(result.propagated.has("B")).toBe(true);
+    expect(result.propagated.has("C")).toBe(true);
+    expect(result.propagated.has("D")).toBe(false);
+  });
+
+  it("bidirectional: A→B also flows B→A via incoming", () => {
+    const graph = makeGraph([["A", "B"]]);
+    const result = computeActivationSpread("B", 1.0, graph);
+
+    // B is source. A is reachable via incoming edge (B← A, i.e. A→B, so A is in outgoing.A but B is in incoming.B)
+    // Actually: A→B means outgoing.A has B, incoming.B has A.
+    // From B, undirected neighbors = outgoing.B ∪ incoming.B = {} ∪ {A} = {A}
+    expect(result.propagated.get("A")).toBeCloseTo(0.6, 6);
+  });
+
+  it("cycle A→B→C→A: each counted once (shortest path)", () => {
+    const graph = makeGraph([["A", "B"], ["B", "C"], ["C", "A"]]);
+    const result = computeActivationSpread("A", 1.0, graph);
+
+    // B: hop 1 via outgoing A→B = 0.6
+    // C: hop 1 via incoming C→A = 0.6 (undirected, A sees C as neighbor via incoming)
+    // No double-counting — both B and C visited at hop 1
+    expect(result.propagated.get("B")).toBeCloseTo(0.6, 6);
+    expect(result.propagated.get("C")).toBeCloseTo(0.6, 6);
+    expect(result.propagated.has("A")).toBe(false); // no self-boost
+  });
+
+  it("isolated node: empty map", () => {
+    const graph = makeGraph([]);
+    const result = computeActivationSpread("A", 1.0, graph);
+    expect(result.propagated.size).toBe(0);
+  });
+
+  it("disabled config: empty map", () => {
+    const graph = makeGraph([["A", "B"]]);
+    const result = computeActivationSpread("A", 1.0, graph, {
+      ...DEFAULT_ACTIVATION_CONFIG,
+      enabled: false,
+    });
+    expect(result.propagated.size).toBe(0);
+  });
+
+  it("utility 0: empty map", () => {
+    const graph = makeGraph([["A", "B"]]);
+    const result = computeActivationSpread("A", 0, graph);
+    expect(result.propagated.size).toBe(0);
+  });
+
+  it("min_boost filter: very low damped boost excluded", () => {
+    const graph = makeGraph([["A", "B"], ["B", "C"]]);
+    const result = computeActivationSpread("A", 0.02, graph, {
+      ...DEFAULT_ACTIVATION_CONFIG,
+      min_boost: 0.01,
+    });
+
+    // Hop 1: 0.02 * 0.6 = 0.012 >= 0.01 → included
+    expect(result.propagated.has("B")).toBe(true);
+    // Hop 2: 0.02 * 0.36 = 0.0072 < 0.01 → excluded
+    expect(result.propagated.has("C")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SQLite persistence tests
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let db: InstanceType<typeof Database>;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "ori-activation-test-"));
+  const dbPath = path.join(tmpDir, ".ori", "embeddings.db");
+  db = initDB(dbPath);
+});
+
+afterEach(async () => {
+  try { db?.close(); } catch { /* already closed */ }
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("applyActivationBoosts", () => {
+  it("writes boost to DB", () => {
+    const boosts = new Map([["noteA", 0.5]]);
+    applyActivationBoosts(db, boosts);
+
+    const row = db.prepare("SELECT boost, updated FROM boosts WHERE title = ?").get("noteA") as {
+      boost: number;
+      updated: string;
+    };
+    // Per-query cap limits any single boost to 0.05
+    expect(row.boost).toBeCloseTo(0.05, 4);
+    expect(row.updated).toBeTruthy();
+  });
+
+  it("accumulates with decay-before-add", () => {
+    // Insert an old boost: 0.5, 20 days ago
+    const oldDate = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString();
+    db.prepare("INSERT INTO boosts (title, boost, updated) VALUES (?, ?, ?)")
+      .run("noteA", 0.5, oldDate);
+
+    // Apply new boost of 0.1 (capped to 0.05)
+    const boosts = new Map([["noteA", 0.1]]);
+    applyActivationBoosts(db, boosts);
+
+    const row = db.prepare("SELECT boost FROM boosts WHERE title = ?").get("noteA") as {
+      boost: number;
+    };
+
+    // Default rows have access_count=1/session_count=1, so decay uses
+    // Ebbinghaus strengthening rather than the base 0.1 rate.
+    const decayRate = DEFAULT_ACTIVATION_CONFIG.enabled
+      ? 0.1 / (1 + 0.2 * Math.log1p(1) + 0.3 * Math.log1p(1))
+      : 0.1;
+    const decayed = 0.5 * Math.exp(-decayRate * 20);
+    const expected = 1 - (1 - decayed) * (1 - 0.05);
+    expect(row.boost).toBeCloseTo(expected, 2);
+    expect(row.boost).toBeLessThan(0.6);
+  });
+
+  it("clamps at 1.0", () => {
+    // Insert a recent boost of 0.9
+    const recentDate = new Date().toISOString();
+    db.prepare("INSERT INTO boosts (title, boost, updated) VALUES (?, ?, ?)")
+      .run("noteA", 0.9, recentDate);
+
+    // Apply new boost of 0.5 — should clamp at 1.0
+    const boosts = new Map([["noteA", 0.5]]);
+    applyActivationBoosts(db, boosts);
+
+    const row = db.prepare("SELECT boost FROM boosts WHERE title = ?").get("noteA") as {
+      boost: number;
+    };
+    expect(row.boost).toBeLessThanOrEqual(1.0);
+  });
+
+  it("updates timestamp", () => {
+    const oldDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    db.prepare("INSERT INTO boosts (title, boost, updated) VALUES (?, ?, ?)")
+      .run("noteA", 0.3, oldDate);
+
+    applyActivationBoosts(db, new Map([["noteA", 0.1]]));
+
+    const row = db.prepare("SELECT updated FROM boosts WHERE title = ?").get("noteA") as {
+      updated: string;
+    };
+    const updatedTime = new Date(row.updated).getTime();
+    // Should be very recent (within last few seconds)
+    expect(Date.now() - updatedTime).toBeLessThan(5000);
+  });
+});
+
+describe("loadBoosts", () => {
+  it("fresh boost returns full value", () => {
+    const nowISO = new Date().toISOString();
+    db.prepare("INSERT INTO boosts (title, boost, updated) VALUES (?, ?, ?)")
+      .run("noteA", 0.8, nowISO);
+
+    const boosts = loadBoosts(db);
+    expect(boosts.get("noteA")).toBeCloseTo(0.8, 2);
+  });
+
+  it("7-day-old boost is approximately half", () => {
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+    db.prepare("INSERT INTO boosts (title, boost, updated) VALUES (?, ?, ?)")
+      .run("noteA", 1.0, sevenDaysAgo);
+
+    const boosts = loadBoosts(db);
+    const decayRate = 0.1 / (1 + 0.2 * Math.log1p(1) + 0.3 * Math.log1p(1));
+    expect(boosts.get("noteA")).toBeCloseTo(Math.exp(-decayRate * 7), 2);
+  });
+
+  it("30-day-old boost is effectively zero", () => {
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    db.prepare("INSERT INTO boosts (title, boost, updated) VALUES (?, ?, ?)")
+      .run("noteA", 1.0, thirtyDaysAgo);
+
+    const boosts = loadBoosts(db);
+    const decayRate = 0.1 / (1 + 0.2 * Math.log1p(1) + 0.3 * Math.log1p(1));
+    const val = boosts.get("noteA") ?? 0;
+    expect(val).toBeCloseTo(Math.exp(-decayRate * 30), 2);
+    expect(val).toBeLessThan(0.12);
+  });
+
+  it("missing title returns undefined (not in map)", () => {
+    const boosts = loadBoosts(db);
+    expect(boosts.has("nonexistent")).toBe(false);
+  });
+});

--- a/tests/core/vault.test.ts
+++ b/tests/core/vault.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  isVaultRoot,
+  findVaultRoot,
+  findVaultRootWithSource,
+  getGlobalVaultPath,
+  getVaultPaths,
+  listNoteTitles,
+} from "../../src/core/vault.js";
+
+let tmpDir: string;
+let fakeHome: string;
+let realHomedir: typeof os.homedir;
+
+beforeEach(async () => {
+  // Use the filesystem root instead of os.tmpdir() so vault discovery cannot
+  // walk upward into the developer's real home vault on Windows.
+  tmpDir = await fs.mkdtemp(path.join(path.parse(os.tmpdir()).root, "ori-test-vault-"));
+  fakeHome = path.join(tmpDir, "fakehome");
+  await fs.mkdir(fakeHome, { recursive: true });
+  realHomedir = os.homedir;
+  os.homedir = () => fakeHome;
+});
+
+afterEach(async () => {
+  os.homedir = realHomedir;
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("isVaultRoot", () => {
+  it("returns true when .ori marker exists", async () => {
+    await fs.writeFile(path.join(tmpDir, ".ori"), "", "utf8");
+    expect(await isVaultRoot(tmpDir)).toBe(true);
+  });
+
+  it("returns false when no .ori marker", async () => {
+    expect(await isVaultRoot(tmpDir)).toBe(false);
+  });
+});
+
+describe("findVaultRoot", () => {
+  it("finds vault root in current directory", async () => {
+    await fs.writeFile(path.join(tmpDir, ".ori"), "", "utf8");
+    const root = await findVaultRoot(tmpDir);
+    expect(root).toBe(path.resolve(tmpDir));
+  });
+
+  it("walks up directories to find .ori", async () => {
+    await fs.writeFile(path.join(tmpDir, ".ori"), "", "utf8");
+    const subDir = path.join(tmpDir, "sub", "deep");
+    await fs.mkdir(subDir, { recursive: true });
+    const root = await findVaultRoot(subDir);
+    expect(root).toBe(path.resolve(tmpDir));
+  });
+
+  it("falls back to the global vault when one exists", async () => {
+    const globalVault = getGlobalVaultPath();
+    await fs.mkdir(path.join(globalVault, ".ori"), { recursive: true });
+
+    const result = await findVaultRootWithSource(tmpDir);
+    expect(result.path).toBe(path.resolve(globalVault));
+    expect(result.source).toBe("global");
+    await expect(findVaultRoot(tmpDir)).resolves.toBe(path.resolve(globalVault));
+  });
+
+  it("throws when neither project nor global vault exists", async () => {
+    await expect(findVaultRoot(tmpDir)).rejects.toThrow("No .ori marker found");
+  });
+});
+
+describe("getVaultPaths", () => {
+  it("returns correct path structure", () => {
+    const paths = getVaultPaths("/my/vault");
+    expect(paths.root).toBe("/my/vault");
+    expect(paths.marker).toBe(path.join("/my/vault", ".ori"));
+    expect(paths.config).toBe(path.join("/my/vault", "ori.config.yaml"));
+    expect(paths.notes).toBe(path.join("/my/vault", "notes"));
+    expect(paths.inbox).toBe(path.join("/my/vault", "inbox"));
+    expect(paths.templates).toBe(path.join("/my/vault", "templates"));
+    expect(paths.ops).toBe(path.join("/my/vault", "ops"));
+    expect(paths.opsSessions).toBe(path.join("/my/vault", "ops", "sessions"));
+    expect(paths.opsObservations).toBe(
+      path.join("/my/vault", "ops", "observations")
+    );
+  });
+});
+
+describe("listNoteTitles", () => {
+  it("returns .md filenames without extension", async () => {
+    const notesDir = path.join(tmpDir, "notes");
+    await fs.mkdir(notesDir);
+    await fs.writeFile(path.join(notesDir, "alpha.md"), "# Alpha", "utf8");
+    await fs.writeFile(path.join(notesDir, "beta.md"), "# Beta", "utf8");
+    const titles = await listNoteTitles(notesDir);
+    expect(titles.sort()).toEqual(["alpha", "beta"]);
+  });
+
+  it("ignores non-.md files", async () => {
+    const notesDir = path.join(tmpDir, "notes");
+    await fs.mkdir(notesDir);
+    await fs.writeFile(path.join(notesDir, "note.md"), "# Note", "utf8");
+    await fs.writeFile(path.join(notesDir, "readme.txt"), "text", "utf8");
+    await fs.writeFile(path.join(notesDir, "data.json"), "{}", "utf8");
+    const titles = await listNoteTitles(notesDir);
+    expect(titles).toEqual(["note"]);
+  });
+
+  it("returns empty array for missing directory", async () => {
+    const titles = await listNoteTitles(path.join(tmpDir, "nonexistent"));
+    expect(titles).toEqual([]);
+  });
+
+  it("ignores subdirectories", async () => {
+    const notesDir = path.join(tmpDir, "notes");
+    await fs.mkdir(notesDir);
+    await fs.mkdir(path.join(notesDir, "subdir.md"));
+    await fs.writeFile(path.join(notesDir, "real.md"), "# Real", "utf8");
+    const titles = await listNoteTitles(notesDir);
+    expect(titles).toEqual(["real"]);
+  });
+});

--- a/tests/e2e/auto-init.test.ts
+++ b/tests/e2e/auto-init.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  findVaultRoot,
+  findVaultRootWithSource,
+  getGlobalVaultPath,
+  isVaultRoot,
+} from "../../src/core/vault.js";
+import { runInit } from "../../src/cli/init.js";
+
+let tmpDir: string;
+let fakeHome: string;
+let realHomedir: typeof os.homedir;
+
+beforeEach(async () => {
+  // Use the filesystem root instead of os.tmpdir() so vault discovery cannot
+  // walk upward into the developer's real home vault on Windows.
+  tmpDir = await fs.mkdtemp(path.join(path.parse(os.tmpdir()).root, "ori-autoinit-"));
+  fakeHome = path.join(tmpDir, "fakehome");
+  await fs.mkdir(fakeHome, { recursive: true });
+
+  // Mock os.homedir to isolate tests from real home directory
+  realHomedir = os.homedir;
+  os.homedir = () => fakeHome;
+});
+
+afterEach(async () => {
+  os.homedir = realHomedir;
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("getGlobalVaultPath", () => {
+  it("returns ~/.ori-memory", () => {
+    expect(getGlobalVaultPath()).toBe(path.join(fakeHome, ".ori-memory"));
+  });
+});
+
+describe("findVaultRoot — global fallback", () => {
+  it("throws when no vault anywhere and no global vault", async () => {
+    const noVaultDir = path.join(tmpDir, "empty");
+    await fs.mkdir(noVaultDir, { recursive: true });
+    await expect(findVaultRoot(noVaultDir)).rejects.toThrow("No .ori marker found");
+  });
+
+  it("returns project vault when it exists", async () => {
+    const projectDir = path.join(tmpDir, "project");
+    await fs.mkdir(projectDir, { recursive: true });
+    await fs.mkdir(path.join(projectDir, ".ori"), { recursive: true });
+    const root = await findVaultRoot(projectDir);
+    expect(root).toBe(path.resolve(projectDir));
+  });
+
+  it("returns global vault when no project vault exists", async () => {
+    // Create global vault at fakeHome/.ori-memory/
+    const globalPath = path.join(fakeHome, ".ori-memory");
+    await fs.mkdir(globalPath, { recursive: true });
+    await fs.mkdir(path.join(globalPath, ".ori"), { recursive: true });
+
+    // Search from a directory with no vault
+    const noVaultDir = path.join(tmpDir, "novault");
+    await fs.mkdir(noVaultDir, { recursive: true });
+    const root = await findVaultRoot(noVaultDir);
+    expect(root).toBe(path.resolve(globalPath));
+  });
+
+  it("project vault wins over global vault", async () => {
+    // Create global vault
+    const globalPath = path.join(fakeHome, ".ori-memory");
+    await fs.mkdir(globalPath, { recursive: true });
+    await fs.mkdir(path.join(globalPath, ".ori"), { recursive: true });
+
+    // Create project vault
+    const projectDir = path.join(tmpDir, "myproject");
+    await fs.mkdir(projectDir, { recursive: true });
+    await fs.mkdir(path.join(projectDir, ".ori"), { recursive: true });
+
+    const root = await findVaultRoot(projectDir);
+    expect(root).toBe(path.resolve(projectDir));
+  });
+});
+
+describe("findVaultRootWithSource", () => {
+  it("returns source: project for project vault", async () => {
+    const projectDir = path.join(tmpDir, "project");
+    await fs.mkdir(projectDir, { recursive: true });
+    await fs.mkdir(path.join(projectDir, ".ori"), { recursive: true });
+
+    const result = await findVaultRootWithSource(projectDir);
+    expect(result.source).toBe("project");
+    expect(result.path).toBe(path.resolve(projectDir));
+  });
+
+  it("returns source: global for global vault", async () => {
+    const globalPath = path.join(fakeHome, ".ori-memory");
+    await fs.mkdir(globalPath, { recursive: true });
+    await fs.mkdir(path.join(globalPath, ".ori"), { recursive: true });
+
+    const noVaultDir = path.join(tmpDir, "novault");
+    await fs.mkdir(noVaultDir, { recursive: true });
+
+    const result = await findVaultRootWithSource(noVaultDir);
+    expect(result.source).toBe("global");
+    expect(result.path).toBe(path.resolve(globalPath));
+  });
+
+  it("throws with clear message when --vault points to nonexistent path", async () => {
+    const badPath = path.join(tmpDir, "nonexistent");
+    await expect(findVaultRootWithSource(tmpDir, badPath)).rejects.toThrow(
+      "Vault not found at specified path",
+    );
+  });
+
+  it("--vault override never falls back to global", async () => {
+    // Create global vault
+    const globalPath = path.join(fakeHome, ".ori-memory");
+    await fs.mkdir(globalPath, { recursive: true });
+    await fs.mkdir(path.join(globalPath, ".ori"), { recursive: true });
+
+    // Override points to non-vault — should throw, NOT fall back to global
+    const badOverride = path.join(tmpDir, "badoverride");
+    await fs.mkdir(badOverride, { recursive: true });
+    await expect(findVaultRootWithSource(tmpDir, badOverride)).rejects.toThrow(
+      "Vault not found at specified path",
+    );
+  });
+});
+
+describe("serve auto-create simulation", () => {
+  // Simulates what serve.ts does: try findVaultRootWithSource, on failure auto-create
+
+  async function serveAutoCreate(startDir: string, vaultOverride?: string) {
+    let autoCreated = false;
+    let vaultRoot: string;
+
+    try {
+      const result = await findVaultRootWithSource(startDir, vaultOverride);
+      vaultRoot = result.path;
+    } catch (err) {
+      if (vaultOverride) throw err;
+      const globalPath = getGlobalVaultPath();
+      await runInit({ targetDir: globalPath });
+      vaultRoot = globalPath;
+      autoCreated = true;
+    }
+
+    return { vaultRoot, autoCreated };
+  }
+
+  it("auto-creates global vault when no vault exists", async () => {
+    const noVaultDir = path.join(tmpDir, "empty");
+    await fs.mkdir(noVaultDir, { recursive: true });
+
+    const result = await serveAutoCreate(noVaultDir);
+    expect(result.autoCreated).toBe(true);
+    expect(result.vaultRoot).toBe(path.join(fakeHome, ".ori-memory"));
+
+    // Verify scaffold was created
+    expect(await isVaultRoot(result.vaultRoot)).toBe(true);
+    const identityPath = path.join(result.vaultRoot, "self", "identity.md");
+    const identity = await fs.readFile(identityPath, "utf8");
+    expect(identity).toContain("<!-- First session:");
+  });
+
+  it("auto-created vault triggers isFirstRun", async () => {
+    const noVaultDir = path.join(tmpDir, "empty");
+    await fs.mkdir(noVaultDir, { recursive: true });
+
+    const result = await serveAutoCreate(noVaultDir);
+    const identityPath = path.join(result.vaultRoot, "self", "identity.md");
+    const identity = await fs.readFile(identityPath, "utf8");
+
+    // isFirstRun checks: strip frontmatter, check for scaffold marker or empty content
+    expect(identity).toContain("<!-- First session:");
+  });
+
+  it("--vault /nonexistent throws, does NOT auto-create", async () => {
+    const badPath = path.join(tmpDir, "bad");
+    await expect(serveAutoCreate(tmpDir, badPath)).rejects.toThrow(
+      "Vault not found at specified path",
+    );
+
+    // Global vault should NOT have been created
+    const globalPath = path.join(fakeHome, ".ori-memory");
+    expect(await isVaultRoot(globalPath)).toBe(false);
+  });
+
+  it("second call after auto-create returns existing vault, autoCreated false", async () => {
+    const noVaultDir = path.join(tmpDir, "empty");
+    await fs.mkdir(noVaultDir, { recursive: true });
+
+    // First call — auto-creates
+    const first = await serveAutoCreate(noVaultDir);
+    expect(first.autoCreated).toBe(true);
+
+    // Second call — finds existing global vault via findVaultRootWithSource
+    const second = await serveAutoCreate(noVaultDir);
+    expect(second.autoCreated).toBe(false);
+    expect(second.vaultRoot).toBe(first.vaultRoot);
+  });
+});

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -50,12 +50,13 @@ describe("server initialization", () => {
 // ---------------------------------------------------------------------------
 
 describe("tools listing", () => {
-  it("lists all 15 tools", async () => {
+  it("lists all exposed tools", async () => {
     const result = await ctx.client.listTools();
     const toolNames = result.tools.map((t) => t.name).sort();
 
     expect(toolNames).toEqual([
       "ori_add",
+      "ori_explore",
       "ori_health",
       "ori_index_build",
       "ori_orient",


### PR DESCRIPTION
Cleans up the ambient local test failures we saw while reviewing OpenCode.

Changes:
- whitelists the focused ignored tests that `npm test` already runs locally
- isolates vault/global-fallback tests from a developer's real home vault on Windows
- updates activation decay assertions for the current Ebbinghaus-aware decay logic
- updates MCP tool listing expectation to include `ori_explore`

Verification:
- `npm test -- --run` ✅ 40 files / 620 tests passing
