### PR TITLE
fix(vitality): write back access_count on retrieval

### DIFF
--- a/src/cli/search.ts
+++ b/src/cli/search.ts
@@ -49,6 +49,7 @@ import {
   applyHubDampening,
   applyResolutionBoost,
 } from "../core/dampening.js";
+import { readFrontmatterFile, writeFrontmatterFile } from "../core/frontmatter.js";
 
 type WarmthRankShift = {
   title: string;
@@ -525,7 +526,19 @@ export async function runQueryRanked(
     await logWarmthAudit(vaultRoot, auditEvent);
   }
 
-  // 15. Spreading activation: propagate boosts to neighbors of top results
+  // 15. Update access metadata in frontmatter for retrieved notes
+  const today = new Date().toISOString().split("T")[0];
+  await Promise.allSettled(withExploration.map(async (result) => {
+    const notePath = path.join(paths.notes, `${result.title}.md`);
+    const { data, body } = await readFrontmatterFile(notePath);
+    if (data) {
+      data.access_count = (typeof data.access_count === "number" ? data.access_count : 0) + 1;
+      data.last_accessed = today;
+      await writeFrontmatterFile(notePath, data, body);
+    }
+  }));
+
+  // 16. Spreading activation: propagate boosts to neighbors of top results
   if (config.activation?.enabled !== false) {
     const allBoosts = new Map<string, number>();
     for (const result of withExploration.slice(0, 3)) {
@@ -544,7 +557,7 @@ export async function runQueryRanked(
     }
   }
 
-  // 16. Close DB only if we opened it ourselves
+  // 17. Close DB only if we opened it ourselves
   if (ownDb) {
     mainDb.close();
   }


### PR DESCRIPTION
Note that this isn't finished. I meant to write tests and never got to it, so it's untested. Opening
it as a reference so you can compare it against your in-house version and take whichever is better.

It's a small change in `src/cli/search.ts`. Once a ranked query has its results, it bumps
`access_count` and writes today's date into `last_accessed` on each returned note. It resolves note
paths the same way `noteindex.ts` does and reuses the existing `readFrontmatterFile` /
`writeFrontmatterFile` helpers. Writes are best effort under `Promise.allSettled`, so one unreadable
note can't sink the query.

I ran it against a scratch vault and it works.

Two things worth knowing before you pick an approach.

A note gets counted whenever it's returned, relevant or not. I put an unrelated note in the test
vault, asked only questions it had nothing to do with, and its counter climbed as fast as the real
matches. In a small vault everything comes back for every query, so the counts go flat and tell you
nothing. They only mean something once a vault is big enough that a query returns a subset. Your
version sounds like it does the same, so this isn't an argument against either. Just worth naming.

Minor: `notes/index.md` now picks up an `access_count` field it never had.

Refs #17.
